### PR TITLE
Manual input tool

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,9 @@
         },
         "mission-testronaut/testronaut-examples": {
           "permissions": "write-all"
+        },
+        "mission-testronaut/testronaut-demo": {
+          "permissions": "write-all"
         }
       }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
           "permissions": "write-all"
         },
         "mission-testronaut/testronaut-demo": {
-          "permissions": "read-all"
+          "permissions": "write-all"
         }
       }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,20 @@
 
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
 
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "secrets": {
+    "GH_TOKEN": {
+      "description": "A GitHub PAT with read access to mission-testronaut/testronaut-demo."
+    }
+  },
+
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
+
   "customizations": {
     "codespaces": {
       "repositories": {
@@ -40,9 +54,9 @@
 
   "workspaceFolder": "/workspaces",
 
-  "postCreateCommand": "bash -lc 'set -e; cd /workspaces; if [ ! -d \"testronaut-examples/.git\" ]; then git clone https://github.com/mission-testronaut/testronaut-examples.git; fi; if [ ! -d \"testronaut-demo/.git\" ]; then git clone https://github.com/mission-testronaut/testronaut-demo.git; fi'",
+  "postCreateCommand": "bash /workspaces/testronaut-cli/.devcontainer/setup-github-auth.sh",
 
-  "postStartCommand": "bash -lc 'git config --global pull.rebase false && git config --global init.defaultBranch main'",
+  "postStartCommand": "bash /workspaces/testronaut-cli/.devcontainer/setup-github-auth.sh",
 
   "hostRequirements": {
     "cpus": 4,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
           "permissions": "write-all"
         },
         "mission-testronaut/testronaut-demo": {
-          "permissions": "write-all"
+          "permissions": "read-all"
         }
       }
     },
@@ -40,7 +40,7 @@
 
   "workspaceFolder": "/workspaces",
 
-  "postCreateCommand": "bash -lc 'set -e; cd /workspaces; if [ ! -d \"testronaut-examples/.git\" ]; then git clone https://github.com/mission-testronaut/testronaut-examples.git; fi'",
+  "postCreateCommand": "bash -lc 'set -e; cd /workspaces; if [ ! -d \"testronaut-examples/.git\" ]; then git clone https://github.com/mission-testronaut/testronaut-examples.git; fi; if [ ! -d \"testronaut-demo/.git\" ]; then git clone https://github.com/mission-testronaut/testronaut-demo.git; fi'",
 
   "postStartCommand": "bash -lc 'git config --global pull.rebase false && git config --global init.defaultBranch main'",
 

--- a/.devcontainer/setup-github-auth.sh
+++ b/.devcontainer/setup-github-auth.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspaces
+
+git config --global pull.rebase false
+git config --global init.defaultBranch main
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is not installed. Rebuild the devcontainer so the github-cli feature is installed."
+  exit 1
+fi
+
+if [ -n "${GH_TOKEN:-}" ] && ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  printf '%s\n' "$GH_TOKEN" | gh auth login --hostname github.com --with-token >/dev/null
+fi
+
+if gh auth status --hostname github.com >/dev/null 2>&1; then
+  gh auth setup-git --hostname github.com
+else
+  echo "GitHub CLI is not authenticated."
+  echo "Add GH_TOKEN as a Codespaces secret with access to mission-testronaut/testronaut-demo."
+  exit 1
+fi
+
+clone_if_missing() {
+  local repo="$1"
+  local directory="$2"
+
+  if [ ! -d "$directory/.git" ]; then
+    gh repo clone "$repo" "$directory"
+  fi
+}
+
+clone_if_missing mission-testronaut/testronaut-examples testronaut-examples
+clone_if_missing mission-testronaut/testronaut-demo testronaut-demo

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -364,6 +364,70 @@ if (retryFlagIndex >= 0) {
   args.splice(retryFlagIndex, retryOverride ? 2 : 1);
 }
 
+// Look for --human-input / --no-human-input / --disable-human-input
+let humanInputOverride;
+let humanInputConsumesNext = false;
+const humanInputFlagIndex = args.findIndex(a =>
+  a === '--human-input' ||
+  a.startsWith('--human-input=') ||
+  a === '--human_input' ||
+  a.startsWith('--human_input=') ||
+  a === '--no-human-input' ||
+  a === '--disable-human-input'
+);
+if (humanInputFlagIndex >= 0) {
+  const rawArg = args[humanInputFlagIndex];
+  if (rawArg.includes('=')) {
+    humanInputOverride = parseBool(rawArg.split('=')[1]);
+  } else if (rawArg === '--no-human-input' || rawArg === '--disable-human-input') {
+    humanInputOverride = false;
+  } else if (args[humanInputFlagIndex + 1] && !args[humanInputFlagIndex + 1].startsWith('-')) {
+    humanInputOverride = parseBool(args[humanInputFlagIndex + 1]);
+    humanInputConsumesNext = true;
+  } else {
+    humanInputOverride = true;
+  }
+
+  if (humanInputOverride !== null) {
+    process.env.TESTRONAUT_HUMAN_INPUT = humanInputOverride ? '1' : '0';
+    console.log(`👤 Human input tool ${humanInputOverride ? 'enabled' : 'disabled'} (TESTRONAUT_HUMAN_INPUT=${process.env.TESTRONAUT_HUMAN_INPUT})`);
+  } else {
+    console.warn('⚠️ Invalid --human-input value. Use true/false, 1/0, yes/no.');
+  }
+
+  const consume = 1 + (humanInputConsumesNext && humanInputOverride !== null ? 1 : 0);
+  args.splice(humanInputFlagIndex, consume);
+}
+
+// Look for --human-input-timeout / --human_input_timeout in seconds
+let humanInputTimeoutOverride;
+const humanInputTimeoutFlagIndex = args.findIndex(a =>
+  a === '--human-input-timeout' ||
+  a.startsWith('--human-input-timeout=') ||
+  a === '--human_input_timeout' ||
+  a.startsWith('--human_input_timeout=')
+);
+if (humanInputTimeoutFlagIndex >= 0) {
+  const rawArg = args[humanInputTimeoutFlagIndex];
+  if (rawArg.includes('=')) {
+    humanInputTimeoutOverride = rawArg.split('=')[1];
+  } else if (args[humanInputTimeoutFlagIndex + 1]) {
+    humanInputTimeoutOverride = args[humanInputTimeoutFlagIndex + 1];
+  }
+
+  if (humanInputTimeoutOverride) {
+    const n = Number(humanInputTimeoutOverride.trim());
+    if (Number.isFinite(n) && n > 0) {
+      process.env.TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS = String(n);
+      console.log(`⏱️ Human input timeout override: ${process.env.TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS}s`);
+    } else {
+      console.warn(`⚠️ Invalid --human-input-timeout value "${humanInputTimeoutOverride}". Ignoring.`);
+    }
+  }
+
+  args.splice(humanInputTimeoutFlagIndex, humanInputTimeoutOverride ? 2 : 1);
+}
+
 const allResults = [];
 const runId = `run_${Date.now()}`;
 const startTime = new Date();
@@ -386,6 +450,9 @@ Options:
   --provider=<id>           Override LLM provider for this run (e.g., --provider=openai)
   --dev                     Use the staging API base URL
   --vercel-bypass=<secret>  Send Vercel protection bypass header for protected deployments
+  --human-input[=<bool>]    Allow the agent to pause for short verification codes (default: true)
+  --no-human-input          Disable human-in-the-loop verification prompts for automated runs
+  --human-input-timeout=<s> Override human input wait timeout in seconds (default: 60)
   --help                    Show this help message
   --retry_limit=<n>         Override agent turn retry limits (minimum 1, maximum 10)
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -141,6 +141,7 @@ export async function initializeTestronautProject() {
     config.maxTurns = config.maxTurns ?? defaults.maxTurns;
     config.dom = { ...defaults.dom, ...(config.dom || {}) };
     config.resourceGuard = { ...defaults.resourceGuard, ...(config.resourceGuard || {}) };
+    config.humanInput = { ...defaults.humanInput, ...(config.humanInput || {}) };
 
     // ─────────────────────────────────────────────
     // STEP 4: Persist config and scaffold .env (first run only)

--- a/bin/initHelpers.js
+++ b/bin/initHelpers.js
@@ -60,6 +60,10 @@ export function defaultConfig(rootBasename) {
       hrefIncludes: ['/document/', '/file/', '/download', '/attachment/'],
       dataTypes: ['document', 'file', 'item', 'row'],
     },
+    humanInput: {
+      enabled: true,
+      timeoutSeconds: 60,
+    },
   };
 }
 

--- a/core/agent.js
+++ b/core/agent.js
@@ -36,7 +36,7 @@ import path from 'path';
  * @param {string} missionName
  * @param {number} [maxTurns=20] - upper bound for turnLoop per goal
  * @param {number} [retryLimit]
- * @param {{ domListLimit?: number|typeof Infinity, debug?: boolean, resourceGuard?: { enabled:boolean, hrefIncludes:string[], dataTypes:string[] } }} [opts]
+ * @param {{ domListLimit?: number|typeof Infinity, debug?: boolean, resourceGuard?: { enabled:boolean, hrefIncludes:string[], dataTypes:string[] }, humanInput?: { enabled:boolean, timeoutSeconds:number } }} [opts]
  * @returns {Promise<Array<{missionName:string, submissionType:string, submissionName:string|null, status:'passed'|'failed', steps:any[], startTime:number, endTime:number}>>}
  */
 export async function runAgent(goals, missionName, maxTurns = 20, retryLimit, opts = {}) {
@@ -135,6 +135,17 @@ Use Ground Control as your persistent mission memory about:
 - Any constraints about staying on the correct site.
       `.trim();
 
+      if (opts.humanInput?.enabled !== false) {
+        systemContent +=
+          '\n\n' +
+          `
+Human-in-the-loop verification:
+- If the app requires a TOTP, SMS, email, or similar short verification code that you cannot retrieve yourself, call request_human_input.
+- Do not ask for passwords, API keys, or long free-form text with this tool.
+- After receiving the code from the tool result, enter it into the appropriate field and continue the mission.
+          `.trim();
+      }
+
       if (groundSummary) {
         systemContent +=
           '\n\n' +
@@ -164,6 +175,7 @@ Use Ground Control as your persistent mission memory about:
           retryLimit, 
           groundControl,
           resourceGuard: opts.resourceGuard,
+          humanInput: opts.humanInput,
           onStep: (s) => {
             // Append each step as a JSON line
             try {

--- a/core/config.js
+++ b/core/config.js
@@ -173,6 +173,71 @@ export function getResourceGuardConfig(cfg) {
   return { enabled, hrefIncludes: finalHref, dataTypes: finalTypes };
 }
 
+function parseBool(raw) {
+  if (raw === undefined || raw === null) return null;
+  const lower = String(raw).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on', 'allow', 'enabled'].includes(lower)) return true;
+  if (['0', 'false', 'no', 'off', 'deny', 'disabled'].includes(lower)) return false;
+  return null;
+}
+
+/**
+ * Resolve human-in-the-loop verification input settings.
+ * Priority: CLI/env overrides → testronaut-config.json → built-in defaults.
+ *
+ * Supported config:
+ *   humanInput: { enabled: true, timeoutSeconds: 60 }
+ *   humanInputEnabled / allowHumanInput
+ *   humanInputTimeoutSeconds / humanInputTimeout
+ *
+ * Supported env (set by CLI flags too):
+ *   TESTRONAUT_HUMAN_INPUT=true|false
+ *   TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS=60
+ *
+ * @param {object} cfg
+ * @param {{ enabled?: boolean, timeoutSeconds?: number }} [fallback]
+ * @returns {{ enabled:boolean, timeoutSeconds:number, source:{ enabled:'env'|'config'|'default', timeout:'env'|'config'|'default' }, clamped:boolean }}
+ */
+export function getHumanInputConfig(cfg, fallback = { enabled: true, timeoutSeconds: 60 }) {
+  const clampTimeout = (raw, fb) => {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return { value: fb, clamped: false };
+    const clamped = Math.min(300, Math.max(5, Math.trunc(n)));
+    return { value: clamped, clamped: clamped !== n };
+  };
+
+  const envEnabled = parseBool(process.env.TESTRONAUT_HUMAN_INPUT);
+  const cfgEnabled = parseBool(cfg?.humanInput?.enabled ?? cfg?.humanInputEnabled ?? cfg?.allowHumanInput);
+  const enabled =
+    envEnabled !== null ? envEnabled :
+    cfgEnabled !== null ? cfgEnabled :
+    fallback.enabled !== false;
+  const enabledSource =
+    envEnabled !== null ? 'env' :
+    cfgEnabled !== null ? 'config' :
+    'default';
+
+  const cfgTimeoutRaw = cfg?.humanInput?.timeoutSeconds ?? cfg?.humanInput?.timeout ?? cfg?.humanInputTimeoutSeconds ?? cfg?.humanInputTimeout;
+  const envTimeoutRaw = process.env.TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS;
+  let timeoutSource = 'default';
+  let timeoutRaw = fallback.timeoutSeconds ?? 60;
+  if (envTimeoutRaw !== undefined) {
+    timeoutRaw = envTimeoutRaw;
+    timeoutSource = 'env';
+  } else if (cfgTimeoutRaw !== undefined) {
+    timeoutRaw = cfgTimeoutRaw;
+    timeoutSource = 'config';
+  }
+
+  const timeout = clampTimeout(timeoutRaw, 60);
+  return {
+    enabled,
+    timeoutSeconds: timeout.value,
+    source: { enabled: enabledSource, timeout: timeoutSource },
+    clamped: timeout.clamped,
+  };
+}
+
 /**
  * Baseline limits for mission runs. Adjust here for global defaults.
  *

--- a/core/redaction.js
+++ b/core/redaction.js
@@ -44,6 +44,9 @@ export const SENSITIVE_KEYWORDS = [
   'auth',
   'pin',
   'otp',
+  'code',
+  'totp',
+  'mfa',
 ];
 
 /**
@@ -140,6 +143,13 @@ function isSensitiveCall(fnName, args = {}) {
  */
 export function redactArgs(fnName, args = {}, { showLength = true } = {}) {
   const out = clone(args);
+
+  if (fnName === 'request_human_input') {
+    for (const key of ['value', 'code', 'input', 'answer', 'redactedValue']) {
+      if (key in out) out[key] = maskPreview(out[key], showLength);
+    }
+    return out;
+  }
 
   // Mask direct props with sensitive-looking keys
   for (const k of Object.keys(out || {})) {

--- a/core/redaction.js
+++ b/core/redaction.js
@@ -49,6 +49,8 @@ export const SENSITIVE_KEYWORDS = [
   'mfa',
 ];
 
+const VERIFICATION_CODE_KEYWORDS = new Set(['otp', 'code', 'totp', 'mfa']);
+
 /**
  * Builds a single RegExp that treats hyphens as `[-_\s]?` to catch variants.
  * @returns {RegExp}
@@ -175,8 +177,8 @@ export function redactArgs(fnName, args = {}, { showLength = true } = {}) {
  * 1) Sensitive-word ... "VALUE"
  *    e.g., `password is "hunter2"`
  *
- * 2) Sensitive-word ... (with|as|to|=) VALUE
- *    e.g., `token=abcd1234`, `auth with xyz`
+ * 2) Sensitive-word ... (with|as|to|=|entered|provided|used|submitted|filled) VALUE
+ *    e.g., `token=abcd1234`, `auth with xyz`, `MFA (entered 123456)`
  *
  * 3) "VALUE" ... into/in/on/to TARGET  (TARGET contains a sensitive hint)
  *    e.g., `Type "Imp0st3r123!" into #access`
@@ -189,18 +191,29 @@ export function redactPasswordInText(text = '', { showLength = true } = {}) {
   let s = String(text ?? '');
 
   // Build a reusable source pattern for SENSITIVE_KEYWORDS with hyphen expansion
-  const kwParts = SENSITIVE_KEYWORDS.map(k => k.replace(/-/g, '[-_\\s]?'));
-  const kwGroup = `(${kwParts.join('|')})`;
+  const strongKwParts = SENSITIVE_KEYWORDS
+    .filter(k => !VERIFICATION_CODE_KEYWORDS.has(k))
+    .map(k => k.replace(/-/g, '[-_\\s]?'));
+  const verificationKwParts = [...VERIFICATION_CODE_KEYWORDS].map(k => k.replace(/-/g, '[-_\\s]?'));
+  const strongKwGroup = `(${strongKwParts.join('|')})`;
+  const verificationKwGroup = `(${verificationKwParts.join('|')})`;
 
   // Case 1: keyword ... "VALUE"
   s = s.replace(
-    new RegExp(`(\\b${kwGroup}\\b[^"'\\\\\\n]{0,80}["'])([^"']+)(["'])`, 'gi'),
+    new RegExp(`(\\b${strongKwGroup}\\b[^"'\\\\\\n]{0,80}(?:[:=]|\\s)["'])([^"'\\n]+)(["'])`, 'gi'),
     (_m, pre, _kw, secret, post) => pre + maskPreview(secret, showLength) + post
   );
 
-  // Case 2: keyword ... (with|as|to|=) VALUE
+  // Case 2: keyword ... (with|as|to|=|entered|provided|used|submitted|filled) VALUE
   s = s.replace(
-    new RegExp(`(\\b${kwGroup}\\b[^.\\n]{0,80}?\\b(with|as|to|=)\\s*)([^\\s"'\\\`]+)`, 'gi'),
+    new RegExp(`(\\b${strongKwGroup}\\b[^.\\n]{0,80}?(?:\\b(with|as|to|entered|provided|used|submitted|filled)\\b|=)\\s*\\(?)([^\\s"'\\\`),.;:]+)`, 'gi'),
+    (_m, pre, _kw1, _kw2, secret) => pre + maskPreview(secret, showLength)
+  );
+
+  // Verification-code words are common UI text. Only redact them when the
+  // phrasing says a concrete value was entered/provided/etc.
+  s = s.replace(
+    new RegExp(`(\\b${verificationKwGroup}\\b[^.\\n]{0,80}?\\b(entered|provided|used|submitted|filled)\\b\\s*\\(?)([A-Za-z0-9_-]{4,64})`, 'gi'),
     (_m, pre, _kw1, _kw2, secret) => pre + maskPreview(secret, showLength)
   );
 

--- a/core/turnLoop.js
+++ b/core/turnLoop.js
@@ -46,7 +46,7 @@ import {
 import { resolveProviderModel } from '../llm/modelResolver.js';
 import { getLLM } from '../llm/llmFactory.js';
 import { summarizeTurnIntentFromMessage } from './turnIntent.js';
-import { redactArgs } from './redaction.js';
+import { maskPreview, redactArgs } from './redaction.js';
 import { 
   sanitizeHeavyToolHistory, 
   pruneConversationContext,
@@ -132,6 +132,7 @@ const FIRE_AND_FORGET_TOOLS = new Set([
   'click_and_follow_popup',
   'switch_to_page',
   'close_current_page',
+  'request_human_input',
 ]);
 
 /**
@@ -227,7 +228,11 @@ export const turnLoop = async (
   const retryLimitClamped = Math.min(10, Math.max(1, Number.isFinite(retryLimitRaw) ? retryLimitRaw : DEFAULT_TURN_RETRY_LIMIT)); // retries allowed (excludes initial)
   const maxAttempts = retryLimitClamped + 1; // includes initial attempt
   ctx.groundControl = groundControl;
-  let agentMemory = { lastMenuExpanded: false };
+  const humanInput = ctx.humanInput || { enabled: true, timeoutSeconds: 60 };
+  const activeToolsSchema = humanInput.enabled === false
+    ? toolsSchema.filter(t => t?.function?.name !== 'request_human_input')
+    : toolsSchema;
+  let agentMemory = { lastMenuExpanded: false, humanInput };
   ensureDocProgress(agentMemory, resourceGuardCfg);
   let turnRetries = 0;
   let stepSeq = ctx._stepSeq || 0;
@@ -325,7 +330,7 @@ export const turnLoop = async (
       const { message, usage, headers } = await llm.chat({
         model: MODEL_ID,
         messages,
-        tools: toolsSchema,
+        tools: activeToolsSchema,
       });
       response = { message, usage, headers };
 
@@ -412,6 +417,19 @@ export const turnLoop = async (
           hadToolIssues = true;
         }
 
+        if (fnName === 'request_human_input') {
+          step.humanInput = step.humanInput || {};
+          step.humanInput.requested = true;
+          step.humanInput.codeType = args.codeType || 'verification_code';
+          step.humanInput.timeoutSeconds = humanInput.timeoutSeconds;
+          step.humanInput.status = errorMessage
+            ? (String(errorMessage).toLowerCase().includes('timed out') ? 'timeout' : 'invalid')
+            : 'provided';
+          step.events.push(errorMessage
+            ? `👤 Human-in-the-loop input ${step.humanInput.status}: ${errorMessage.replace(/^ERROR:\s*/, '')}`
+            : '👤 Human-in-the-loop input provided.');
+        }
+
         // Capture and log any file upload/download events (for reports)
         try {
           const maybeJson = JSON.parse(result);
@@ -443,7 +461,20 @@ export const turnLoop = async (
         }
 
         console.log(`[tool ] ← ${fnName} result:`, errorMessage ? '❌ Failed' : '✅ Success');
-        const truncated = result.length > 1000 ? result.slice(0, 1000) + '…' : result;
+        let resultForLog = result;
+        if (fnName === 'request_human_input') {
+          try {
+            const parsed = JSON.parse(result);
+            resultForLog = JSON.stringify({
+              ...parsed,
+              value: maskPreview(parsed.value),
+              redactedValue: maskPreview(parsed.value),
+            });
+          } catch {
+            resultForLog = errorMessage || 'Human input received.';
+          }
+        }
+        const truncated = resultForLog.length > 1000 ? resultForLog.slice(0, 1000) + '…' : resultForLog;
         step.events.push(`[tool ] ← ${fnName} result: ${errorMessage ? '❌ Failed' : '✅ Success'}`);
         step.events.push(`[tool ] ← ${truncated}`);
 

--- a/runner/testronaut.js
+++ b/runner/testronaut.js
@@ -27,7 +27,7 @@ import fs from 'fs';
 import path from 'path';
 import { runAgent } from '../core/agent.js';
 import { redactPasswordInText } from '../core/redaction.js';
-import { loadConfig, enforceTurnBudget, getRetryLimit, getDomListLimit, getResourceGuardConfig } from '../core/config.js';
+import { loadConfig, enforceTurnBudget, getRetryLimit, getDomListLimit, getResourceGuardConfig, getHumanInputConfig } from '../core/config.js';
 
 // Check process env for debug toggles (shared helper for tests and CLI).
 const isDebugEnabled = () => {
@@ -53,6 +53,7 @@ export async function runMissions({ preMission, mission, postMission }, missionN
   const retryLimit = retryInfo.value;
   const domListLimitInfo = getDomListLimit(cfg);
   const resourceGuard = getResourceGuardConfig(cfg);
+  const humanInput = getHumanInputConfig(cfg);
   const debugEnabled = isDebugEnabled();
   if (notes.length) {
     console.warn(notes.join('\n'));
@@ -65,6 +66,12 @@ export async function runMissions({ preMission, mission, postMission }, missionN
   }
   if (domListLimitInfo?.mode === 'all') {
     console.warn('⚠️ DOM list limit is set to "all". This can dramatically increase token usage and may break flows on heavy pages.');
+  }
+  if (humanInput.clamped) {
+    console.warn(`⚠️ Human input timeout clamped to ${humanInput.timeoutSeconds}s (allowed 5-300).`);
+  }
+  if (!humanInput.enabled) {
+    console.log('👤 Human-in-the-loop input tool disabled for this run.');
   }
   if (debugEnabled) {
     const cfgDomRaw = cfg?.dom?.listItemLimit ?? cfg?.dom?.listLimit ?? cfg?.domListLimit;
@@ -88,6 +95,12 @@ export async function runMissions({ preMission, mission, postMission }, missionN
       enabled: resourceGuard.enabled,
       hrefIncludes: resourceGuard.hrefIncludes,
       dataTypes: resourceGuard.dataTypes,
+    });
+    console.log('[debug] Human input', {
+      enabled: humanInput.enabled,
+      timeoutSeconds: humanInput.timeoutSeconds,
+      source: humanInput.source,
+      clamped: humanInput.clamped,
     });
     // Helpful for upload missions: show missions/files contents
     const filesDir = path.resolve(process.cwd(), 'missions/files');
@@ -188,7 +201,7 @@ export async function runMissions({ preMission, mission, postMission }, missionN
     missionName,
     maxTurns,
     retryLimit,
-    { domListLimit: domListLimitInfo?.value, debug: debugEnabled, resourceGuard }
+    { domListLimit: domListLimitInfo?.value, debug: debugEnabled, resourceGuard, humanInput }
   );
   if (!success) {
     console.log(`❌ Aborting after failed goal.`);

--- a/tests/binTests/init.test.js
+++ b/tests/binTests/init.test.js
@@ -79,6 +79,8 @@ describe('initializeTestronautProject', () => {
     expect(typeof cfg.maxTurns).toBe('number');
     expect(cfg.dom?.listItemLimit).toBe(3);
     expect(cfg.resourceGuard?.enabled).toBe(true);
+    expect(cfg.humanInput?.enabled).toBe(true);
+    expect(cfg.humanInput?.timeoutSeconds).toBe(60);
 
     // .env
     const envPath = path.join(temp, '.env');
@@ -112,6 +114,8 @@ describe('initializeTestronautProject', () => {
     expect(cfg.model).toBe('gemini-2.5-flash');
     expect(cfg.dom?.listItemLimit).toBe(3);
     expect(cfg.resourceGuard?.enabled).toBe(true);
+    expect(cfg.humanInput?.enabled).toBe(true);
+    expect(cfg.humanInput?.timeoutSeconds).toBe(60);
 
     const envTxt = fs.readFileSync(path.join(temp, '.env'), 'utf8');
     expect(envTxt).toMatch(/GEMINI_API_KEY=AIza/);
@@ -191,5 +195,7 @@ describe('initializeTestronautProject', () => {
     expect(cfg.maxTurns).toBe(20); // default filled in
     expect(cfg.dom?.listItemLimit).toBe(3);
     expect(cfg.resourceGuard?.enabled).toBe(true);
+    expect(cfg.humanInput?.enabled).toBe(true);
+    expect(cfg.humanInput?.timeoutSeconds).toBe(60);
   });
 });

--- a/tests/binTests/initHelpersTests/defaultConfig.test.js
+++ b/tests/binTests/initHelpersTests/defaultConfig.test.js
@@ -11,5 +11,7 @@ describe('defaultConfig', () => {
     expect(cfg.dom?.listItemLimit).toBe(3);
     expect(cfg.resourceGuard?.enabled).toBe(true);
     expect(cfg.resourceGuard?.hrefIncludes).toContain('/document/');
+    expect(cfg.humanInput?.enabled).toBe(true);
+    expect(cfg.humanInput?.timeoutSeconds).toBe(60);
   });
 });

--- a/tests/coreTests/config.test.js
+++ b/tests/coreTests/config.test.js
@@ -13,6 +13,7 @@ import {
   enforceTurnBudget,
   getDomListLimit,
   getResourceGuardConfig,
+  getHumanInputConfig,
 } from '../../core/config.js';
 
 describe('core/config', () => {
@@ -198,6 +199,45 @@ describe('core/config', () => {
       expect(res.enabled).toBe(true);
       expect(res.hrefIncludes).toEqual(['/x', '/y']);
       expect(res.dataTypes).toEqual(['row']);
+    });
+  });
+
+  describe('getHumanInputConfig', () => {
+    const OLD_ENV = { ...process.env };
+    beforeEach(() => {
+      process.env = { ...OLD_ENV };
+      delete process.env.TESTRONAUT_HUMAN_INPUT;
+      delete process.env.TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS;
+    });
+    afterEach(() => {
+      process.env = { ...OLD_ENV };
+    });
+
+    it('defaults to enabled with a 60 second timeout', () => {
+      const res = getHumanInputConfig({});
+      expect(res.enabled).toBe(true);
+      expect(res.timeoutSeconds).toBe(60);
+      expect(res.source.enabled).toBe('default');
+      expect(res.source.timeout).toBe('default');
+    });
+
+    it('uses config values and clamps timeout', () => {
+      const res = getHumanInputConfig({ humanInput: { enabled: false, timeoutSeconds: 999 } });
+      expect(res.enabled).toBe(false);
+      expect(res.timeoutSeconds).toBe(300);
+      expect(res.source.enabled).toBe('config');
+      expect(res.source.timeout).toBe('config');
+      expect(res.clamped).toBe(true);
+    });
+
+    it('prefers env overrides over config', () => {
+      process.env.TESTRONAUT_HUMAN_INPUT = 'true';
+      process.env.TESTRONAUT_HUMAN_INPUT_TIMEOUT_SECONDS = '7';
+      const res = getHumanInputConfig({ humanInput: { enabled: false, timeoutSeconds: 120 } });
+      expect(res.enabled).toBe(true);
+      expect(res.timeoutSeconds).toBe(7);
+      expect(res.source.enabled).toBe('env');
+      expect(res.source.timeout).toBe('env');
     });
   });
 

--- a/tests/coreTests/redation.test.js
+++ b/tests/coreTests/redation.test.js
@@ -75,6 +75,14 @@ describe('redaction utilities', () => {
       const redacted = redactArgs('fill', args);
       expect(redacted.text).toBe('hello world');
     });
+
+    it('masks human input tool values', () => {
+      const args = { prompt: 'Enter code', value: '123456', code: '654321' };
+      const redacted = redactArgs('request_human_input', args);
+      expect(redacted.prompt).toBe('Enter code');
+      expect(redacted.value).toBe('•••••• (6)');
+      expect(redacted.code).toBe('•••••• (6)');
+    });
   });
 
   describe('redactPasswordInText', () => {

--- a/tests/coreTests/redation.test.js
+++ b/tests/coreTests/redation.test.js
@@ -99,6 +99,13 @@ describe('redaction utilities', () => {
       expect(out).toContain(`auth with •••••• (3)`);
     });
 
+    it('masks MFA codes mentioned as entered in final text', () => {
+      const input = `SUCCESS: Logged in as ISAAC, completed MFA (entered 123456), and reached the dashboard.`;
+      const out = redactPasswordInText(input);
+      expect(out).toContain(`MFA (entered •••••• (6))`);
+      expect(out).not.toContain('123456');
+    });
+
     it('Case 3: "VALUE" into sensitive target (#access)', () => {
       const input = `Type "Imp0st3r123!" into #access`;
       const out = redactPasswordInText(input);
@@ -109,6 +116,21 @@ describe('redaction utilities', () => {
       const input = `Click the button and type "hello" into #search`;
       const out = redactPasswordInText(input);
       expect(out).toBe(input);
+    });
+
+    it('does not mangle MFA mission instructions while masking the access value', () => {
+      const input = `Fill the access code field (#access) with sword.
+Check the "Challenge with MFA code" checkbox.
+Set MFA code digits to 8.
+There should be an MFA challenge. Prompt the user for an MFA code, then fill the MFA Code field (#mfa-code) with that code.
+Click the "Verify Code" button (#mfa-submit).`;
+      const out = redactPasswordInText(input);
+      expect(out).toContain('Fill the access code field (#access) with •••••• (5)');
+      expect(out).toContain('Check the "Challenge with MFA code" checkbox.');
+      expect(out).toContain('Set MFA code digits to 8.');
+      expect(out).toContain('with that code.');
+      expect(out).toContain('Click the "Verify Code" button (#mfa-submit).');
+      expect(out).not.toContain('sword');
     });
 
     it('handles api key forms with spaces/underscores/hyphens', () => {

--- a/tests/coreTests/turnLoop.test.js
+++ b/tests/coreTests/turnLoop.test.js
@@ -94,6 +94,7 @@ vi.mock('../../core/turnIntent.js', () => ({
 }));
 
 vi.mock('../../core/redaction.js', () => ({
+  maskPreview: (value) => `masked:${String(value ?? '').length}`,
   redactArgs: (name, args) => args,
 }));
 

--- a/tests/runnerTests/testronaut.test.js
+++ b/tests/runnerTests/testronaut.test.js
@@ -12,10 +12,11 @@ vi.mock('../../core/config.js', () => ({
   getRetryLimit: vi.fn(),
   getDomListLimit: vi.fn(),
   getResourceGuardConfig: vi.fn(),
+  getHumanInputConfig: vi.fn(),
 }));
 
 import { runAgent } from '../../core/agent.js';
-import { loadConfig, enforceTurnBudget, getRetryLimit, getDomListLimit, getResourceGuardConfig } from '../../core/config.js';
+import { loadConfig, enforceTurnBudget, getRetryLimit, getDomListLimit, getResourceGuardConfig, getHumanInputConfig } from '../../core/config.js';
 
 // Adjust the import path if your file lives elsewhere
 import { runMissions, __test__ as testronautInternals } from '../../runner/testronaut.js';
@@ -29,6 +30,7 @@ describe('cli/testronaut.runMissions (with enforceTurnBudget)', () => {
     getRetryLimit.mockReturnValue({ value: 2, source: 'default', clamped: false });
     getDomListLimit.mockReturnValue({ value: 3, mode: 'number', source: 'default', clamped: false });
     getResourceGuardConfig.mockReturnValue({ enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] });
+    getHumanInputConfig.mockReturnValue({ enabled: true, timeoutSeconds: 60, source: { enabled: 'default', timeout: 'default' }, clamped: false });
   });
 
   it('passes effectiveMax to runAgent and logs any notes', async () => {
@@ -56,7 +58,7 @@ describe('cli/testronaut.runMissions (with enforceTurnBudget)', () => {
       expect.stringContaining('Clamping to 200')
     );
     expect(runAgent).toHaveBeenCalledWith(
-      expect.any(Array), 'Budgeted Run', 200, 2, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] } }
+      expect.any(Array), 'Budgeted Run', 200, 2, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] }, humanInput: { enabled: true, timeoutSeconds: 60, source: { enabled: 'default', timeout: 'default' }, clamped: false } }
     );
 
     warn.mockRestore();
@@ -83,7 +85,7 @@ describe('cli/testronaut.runMissions (with enforceTurnBudget)', () => {
     await runMissions({ mission: 'No warnings' }, 'Clean');
 
     expect(warn).not.toHaveBeenCalled();
-    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'Clean', 20, 3, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] } });
+    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'Clean', 20, 3, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] }, humanInput: { enabled: true, timeoutSeconds: 60, source: { enabled: 'default', timeout: 'default' }, clamped: false } });
 
     warn.mockRestore();
     log.mockRestore();
@@ -176,7 +178,7 @@ describe('cli/testronaut.runMissions (with enforceTurnBudget)', () => {
     expect(goals[1].submissionName).toMatch(/^My Mission/);
 
     // Effective max turns and retry limit passed through
-    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'My Mission', 15, 2, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] } });
+    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'My Mission', 15, 2, { domListLimit: 3, debug: false, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] }, humanInput: { enabled: true, timeoutSeconds: 60, source: { enabled: 'default', timeout: 'default' }, clamped: false } });
 
     log.mockRestore();
   });
@@ -215,7 +217,7 @@ describe('cli/testronaut.runMissions (with enforceTurnBudget)', () => {
 
     await runMissions({ mission: 'Debug' }, 'Debug Mission');
 
-    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'Debug Mission', 20, 2, { domListLimit: 3, debug: true, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] } });
+    expect(runAgent).toHaveBeenCalledWith(expect.any(Array), 'Debug Mission', 20, 2, { domListLimit: 3, debug: true, resourceGuard: { enabled: true, hrefIncludes: ['/document/'], dataTypes: ['document'] }, humanInput: { enabled: true, timeoutSeconds: 60, source: { enabled: 'default', timeout: 'default' }, clamped: false } });
 
     log.mockRestore();
   });

--- a/tests/toolsTests/humanInput.test.js
+++ b/tests/toolsTests/humanInput.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeHumanCodeInput,
+  normalizeHumanInputOptions,
+} from '../../tools/humanInput.js';
+
+describe('tools/humanInput', () => {
+  it('accepts short verification codes and removes whitespace', () => {
+    expect(sanitizeHumanCodeInput(' 123 456 ').value).toBe('123456');
+    expect(sanitizeHumanCodeInput('AB-12_cd').ok).toBe(true);
+  });
+
+  it('rejects empty, long, and unsafe input', () => {
+    expect(sanitizeHumanCodeInput('')).toMatchObject({ ok: false, reason: 'empty' });
+    expect(sanitizeHumanCodeInput('a'.repeat(65))).toMatchObject({ ok: false, reason: 'too_long' });
+    expect(sanitizeHumanCodeInput('abc@example.com')).toMatchObject({ ok: false, reason: 'invalid_characters' });
+  });
+
+  it('normalizes timeout and length limits', () => {
+    const low = normalizeHumanInputOptions({ timeoutSeconds: 1, maxLength: 1000 });
+    expect(low.timeoutSeconds).toBe(5);
+    expect(low.maxLength).toBe(64);
+    expect(low.timeoutClamped).toBe(true);
+    expect(low.maxLengthClamped).toBe(true);
+  });
+});

--- a/tests/toolsTests/toolSchema.test.js
+++ b/tests/toolsTests/toolSchema.test.js
@@ -15,6 +15,14 @@ describe('tools/toolSchema', () => {
     expect(entry.function.parameters?.properties).toHaveProperty('dir');
   });
 
+  it('includes request_human_input for verification codes', () => {
+    const entry = toolsSchema.find(t => t.function?.name === 'request_human_input');
+    expect(entry?.type).toBe('function');
+    expect(entry.function.description).toMatch(/verification code/i);
+    expect(entry.function.parameters?.properties?.codeType?.enum).toContain('totp');
+    expect(entry.function.parameters?.properties?.maxLength?.default).toBe(64);
+  });
+
   it('defines navigate and download_file with required fields', () => {
     const nav = toolsSchema.find(t => t.function?.name === 'navigate');
     const download = toolsSchema.find(t => t.function?.name === 'download_file');

--- a/tests/toolsTests/turnLoopUtils.test.js
+++ b/tests/toolsTests/turnLoopUtils.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { finalResponseHandler } from '../../tools/turnLoopUtils.js';
+
+describe('tools/turnLoopUtils', () => {
+  it('redacts verification codes before printing and returning final responses', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const result = finalResponseHandler({
+        content: 'SUCCESS: Logged in, completed MFA (entered 123456), and reached the dashboard.',
+      });
+
+      expect(result).toMatchObject({ success: true });
+      expect(result.finalMessage).toContain('MFA (entered •••••• (6))');
+      expect(result.finalMessage).not.toContain('123456');
+
+      const printed = logSpy.mock.calls.flat().join('\n');
+      expect(printed).toContain('MFA (entered •••••• (6))');
+      expect(printed).not.toContain('123456');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/tools/chromeBrowser.js
+++ b/tools/chromeBrowser.js
@@ -22,6 +22,7 @@ import {
 import fs from 'fs';
 import path from 'path';
 import { ensureBrowsers } from '../tools/playwrightSetup.js';
+import { requestHumanInput } from './humanInput.js';
 
 const FILES_DIR = path.join('missions', 'files');
 const REPORTS_DIR = path.join('missions', 'mission_reports');
@@ -1361,6 +1362,7 @@ export const CHROME_TOOL_MAP = {
   upload_file: (b, args) => b.upload_file(args),
   download_file: (b, args) => b.download_file(args),
   list_local_files: (b, args) => b.list_local_files(args),
+  request_human_input: (b, args, agentMemory) => requestHumanInput(args, agentMemory?.humanInput),
   resource_progress: (b, args, agentMemory) => {
     const prog = agentMemory?.docProgress;
     if (!prog) return JSON.stringify({ enabled: false, total: 0, downloaded: 0, remaining: [] });

--- a/tools/generateHtmlReport.js
+++ b/tools/generateHtmlReport.js
@@ -62,6 +62,9 @@ export function generateHtmlReport(report, outputPath) {
       const attemptLabel = retryNumber > 0
         ? ` (re-attempt ${retryNumber}/${retryTotal || retryNumber})`
         : '';
+      const humanInput = step.humanInput?.requested
+        ? `<span class="hitl" title="Human-in-the-loop input: ${esc(step.humanInput.status || 'requested')}">👤 Human in-the-loop</span>`
+        : '';
       const imgTag = step.screenshotPath
         ? `<img src="${esc(step.screenshotPath)}" alt="screenshot turn ${esc(step.turn ?? idx)}">`
         : '';
@@ -77,6 +80,7 @@ export function generateHtmlReport(report, outputPath) {
         <details class="step" ${ok ? '' : 'open'}>
           <summary>
             <span class="turn">Turn ${esc((step.turn ?? idx) + 1)}${esc(attemptLabel)}</span>
+            ${humanInput}
             ${planSpan}
             <span class="step-result ${ok ? 'ok' : 'bad'}" ${resultTooltip ? `title="${esc(resultTooltip)}"` : ''}>${esc(resultRaw)}</span>
             <span class="tokens">tokens: ${esc(step.tokensUsed ?? '—')} / total: ${esc(step.totalTokensUsed ?? '—')}</span>
@@ -276,6 +280,11 @@ export function generateHtmlReport(report, outputPath) {
     .step summary:hover{ background: rgba(255,255,255,.08); }
 
     .turn{ font-weight:700; }
+    .hitl{
+      color:#fbbf24; border:1px solid rgba(251,191,36,.45);
+      background:rgba(251,191,36,.12); border-radius:999px;
+      padding:2px 8px; font-size:12px; font-weight:700;
+    }
     .plan{
       flex:1; color: var(--text-muted); font-size:12px;
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;

--- a/tools/humanInput.js
+++ b/tools/humanInput.js
@@ -1,4 +1,5 @@
-import { createInterface } from 'node:readline/promises';
+import { createInterface } from 'node:readline';
+import { Writable } from 'node:stream';
 import { stdin as input, stdout as output } from 'node:process';
 import { maskPreview } from '../core/redaction.js';
 
@@ -9,6 +10,21 @@ const DEFAULT_MAX_CODE_LENGTH = 64;
 const MIN_CODE_LENGTH = 1;
 const MAX_CODE_LENGTH = 64;
 const CODE_RE = /^[A-Za-z0-9_-]+$/;
+
+class HiddenInputOutput extends Writable {
+  constructor(realOutput) {
+    super();
+    this.realOutput = realOutput;
+    this.hidden = false;
+  }
+
+  _write(chunk, encoding, callback) {
+    if (!this.hidden) {
+      this.realOutput.write(chunk, encoding);
+    }
+    callback();
+  }
+}
 
 function clampNumber(raw, fallback, min, max) {
   const n = Number(raw);
@@ -57,6 +73,43 @@ export function sanitizeHumanCodeInput(raw, { maxLength = DEFAULT_MAX_CODE_LENGT
   return { ok: true, value };
 }
 
+export function questionWithHiddenInput(prompt, { timeoutMs } = {}) {
+  return new Promise((resolve, reject) => {
+    const maskedOutput = new HiddenInputOutput(output);
+    const rl = createInterface({
+      input,
+      output: maskedOutput,
+      terminal: Boolean(output.isTTY),
+    });
+
+    let settled = false;
+    let timeout;
+
+    function finish(err, answer) {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      maskedOutput.hidden = false;
+      output.write('\n');
+      rl.close();
+      if (err) reject(err);
+      else resolve(answer);
+    }
+
+    if (timeoutMs) {
+      timeout = setTimeout(() => {
+        const err = new Error('Human input timed out.');
+        err.name = 'AbortError';
+        finish(err);
+      }, timeoutMs);
+    }
+
+    output.write(prompt);
+    maskedOutput.hidden = true;
+    rl.question('', (answer) => finish(null, answer));
+  });
+}
+
 export async function requestHumanInput(args = {}, options = {}) {
   const opts = normalizeHumanInputOptions({
     ...options,
@@ -76,19 +129,14 @@ export async function requestHumanInput(args = {}, options = {}) {
   const label = prompt.endsWith(':') ? prompt : `${prompt}:`;
   const timeoutMs = opts.timeoutSeconds * 1000;
 
-  const rl = createInterface({ input, output });
   let answer;
   try {
-    answer = await rl.question(`\n👤 ${label} `, {
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    answer = await questionWithHiddenInput(`\n👤 ${label} `, { timeoutMs });
   } catch (err) {
     if (err?.name === 'AbortError') {
       throw new Error(`Human input timed out after ${opts.timeoutSeconds}s.`);
     }
     throw err;
-  } finally {
-    rl.close();
   }
 
   const sanitized = sanitizeHumanCodeInput(answer, { maxLength: opts.maxLength });
@@ -113,4 +161,5 @@ export const __test__ = {
   MAX_CODE_LENGTH,
   sanitizeHumanCodeInput,
   normalizeHumanInputOptions,
+  questionWithHiddenInput,
 };

--- a/tools/humanInput.js
+++ b/tools/humanInput.js
@@ -1,0 +1,116 @@
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { maskPreview } from '../core/redaction.js';
+
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const MIN_TIMEOUT_SECONDS = 5;
+const MAX_TIMEOUT_SECONDS = 300;
+const DEFAULT_MAX_CODE_LENGTH = 64;
+const MIN_CODE_LENGTH = 1;
+const MAX_CODE_LENGTH = 64;
+const CODE_RE = /^[A-Za-z0-9_-]+$/;
+
+function clampNumber(raw, fallback, min, max) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return { value: fallback, clamped: false };
+  const value = Math.min(max, Math.max(min, Math.trunc(n)));
+  return { value, clamped: value !== n };
+}
+
+export function normalizeHumanInputOptions(opts = {}) {
+  const timeout = clampNumber(
+    opts.timeoutSeconds,
+    DEFAULT_TIMEOUT_SECONDS,
+    MIN_TIMEOUT_SECONDS,
+    MAX_TIMEOUT_SECONDS
+  );
+  const maxLength = clampNumber(
+    opts.maxLength,
+    DEFAULT_MAX_CODE_LENGTH,
+    MIN_CODE_LENGTH,
+    MAX_CODE_LENGTH
+  );
+
+  return {
+    enabled: opts.enabled !== false,
+    timeoutSeconds: timeout.value,
+    timeoutClamped: timeout.clamped,
+    maxLength: maxLength.value,
+    maxLengthClamped: maxLength.clamped,
+  };
+}
+
+export function sanitizeHumanCodeInput(raw, { maxLength = DEFAULT_MAX_CODE_LENGTH } = {}) {
+  const normalizedMax = clampNumber(maxLength, DEFAULT_MAX_CODE_LENGTH, MIN_CODE_LENGTH, MAX_CODE_LENGTH).value;
+  const value = String(raw ?? '').trim().replace(/\s+/g, '');
+
+  if (!value) {
+    return { ok: false, reason: 'empty', value: '' };
+  }
+  if (value.length > normalizedMax) {
+    return { ok: false, reason: 'too_long', value: '' };
+  }
+  if (!CODE_RE.test(value)) {
+    return { ok: false, reason: 'invalid_characters', value: '' };
+  }
+
+  return { ok: true, value };
+}
+
+export async function requestHumanInput(args = {}, options = {}) {
+  const opts = normalizeHumanInputOptions({
+    ...options,
+    maxLength: args.maxLength ?? options.maxLength,
+  });
+
+  if (!opts.enabled) {
+    throw new Error('Human input tool is disabled for this run.');
+  }
+
+  const codeType = String(args.codeType || 'verification_code')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, 40) || 'verification_code';
+  const prompt = String(args.prompt || `Enter ${codeType.replace(/_/g, ' ')}:`).trim();
+  const label = prompt.endsWith(':') ? prompt : `${prompt}:`;
+  const timeoutMs = opts.timeoutSeconds * 1000;
+
+  const rl = createInterface({ input, output });
+  let answer;
+  try {
+    answer = await rl.question(`\n👤 ${label} `, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`Human input timed out after ${opts.timeoutSeconds}s.`);
+    }
+    throw err;
+  } finally {
+    rl.close();
+  }
+
+  const sanitized = sanitizeHumanCodeInput(answer, { maxLength: opts.maxLength });
+  if (!sanitized.ok) {
+    throw new Error(`Human input rejected: ${sanitized.reason}.`);
+  }
+
+  return {
+    ok: true,
+    humanInputProvided: true,
+    codeType,
+    value: sanitized.value,
+    redactedValue: maskPreview(sanitized.value),
+  };
+}
+
+export const __test__ = {
+  DEFAULT_TIMEOUT_SECONDS,
+  MIN_TIMEOUT_SECONDS,
+  MAX_TIMEOUT_SECONDS,
+  DEFAULT_MAX_CODE_LENGTH,
+  MAX_CODE_LENGTH,
+  sanitizeHumanCodeInput,
+  normalizeHumanInputOptions,
+};

--- a/tools/toolSchema.js
+++ b/tools/toolSchema.js
@@ -331,6 +331,34 @@ const toolsSchema = [
   {
     type: 'function',
     function: {
+      name: 'request_human_input',
+      description:
+        'Pause for a human to enter a short verification code such as TOTP, SMS, or email confirmation. Use only when the page requires a code the agent cannot obtain itself.',
+      parameters: {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'Short prompt shown to the human. Do not ask for passwords or long free-form text.'
+          },
+          codeType: {
+            type: 'string',
+            enum: ['totp', 'sms', 'email', 'verification_code', 'other_code'],
+            default: 'verification_code'
+          },
+          maxLength: {
+            type: 'number',
+            default: 64,
+            description: 'Maximum accepted code length. Values are clamped to 1-64.'
+          }
+        },
+        required: ['prompt']
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
       name: 'set_ground_control_state',
       description: 'Update stable mission facts for Ground Control: app URL, current page role, login status, and constraints. Use this when you learn something that should remain true across future turns and should not be forgotten.',
       parameters: {

--- a/tools/turnLoopUtils.js
+++ b/tools/turnLoopUtils.js
@@ -1,16 +1,20 @@
+import { redactPasswordInText } from '../core/redaction.js';
+
 export const finalResponseHandler = (msg) => {
-  const final = msg.content?.trim().toLowerCase();
+  const content = String(msg.content ?? '');
+  const safeContent = redactPasswordInText(content);
+  const final = content.trim().toLowerCase();
   if (final?.startsWith('success')) {
     console.log('\n┏━ FINAL AGENT RESPONSE ━━━━━━━━━━━━━━━━━━━');
-    console.log(msg.content);
+    console.log(safeContent);
     console.log('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-    return { finalMessage: msg.content, success: true};
+    return { finalMessage: safeContent, success: true};
   }
   if (final?.startsWith('failure')) {
     console.log('\n┏━ FINAL AGENT RESPONSE ━━━━━━━━━━━━━━━━━━━');
-    console.log(msg.content);
+    console.log(safeContent);
     console.log('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-    return { finalMessage: msg.content, success: false};
+    return { finalMessage: safeContent, success: false};
   }
   return null;
 }


### PR DESCRIPTION
Summary

Improves human-in-the-loop verification handling and redaction safety in testronaut-cli.

Changes

Masks terminal input when request_human_input prompts for TOTP/MFA/SMS/email verification codes.
Redacts MFA/TOTP/code values from final agent responses before printing or storing them.
Tightens free-text redaction so mission-flow logging no longer mangles normal MFA instructions like “Challenge with MFA code”.
Preserves masking for sensitive values such as access codes, passwords, tokens, and submitted verification codes.
Adds regression coverage for masked final responses and MFA mission-text redaction.
Testing

Ran npm test
Result: 23 test files passed, 174 tests passed.