### PR TITLE
automated mfa tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,63 @@ export VERCEL_AUTOMATION_BYPASS_SECRET=YOUR_SECRET
 # or
 export TESTRONAUT_VERCEL_BYPASS=YOUR_SECRET
 ```
+
+---
+
+## 🔐 Automated MFA Codes
+
+Testronaut can retrieve a stored TOTP MFA code from the Testronaut API during a mission. This uses the `sessionToken` saved by `testronaut login` in the project root `testronaut-config.json`.
+
+The agent will prefer the automated `get_mfa_code` tool when an MFA nickname is known, then fall back to the manual human input tool if the code is unavailable, the entry is missing, the feature is disabled, or the API session cannot access it.
+
+If the nickname is missing or does not match exactly, the tool can call the MFA list endpoint to see available nicknames. It will retry simple case, spacing, or punctuation mismatches, such as `rudy poo` matching `rudy-poo`.
+
+Add a default MFA nickname to `testronaut-config.json`:
+
+```json
+{
+  "sessionToken": "eyJ...",
+  "mfaName": "github-test-mfa"
+}
+```
+
+Or pass the nickname for a single run:
+
+```bash
+testronaut login.mission.js -o mfa=github-test-mfa
+```
+
+Mission text can also name the MFA entry:
+
+```js
+export const loginMission = `
+Log in to GitHub.
+When prompted for MFA, use the MFA nickname github-test-mfa.
+`;
+```
+
+Use staging API endpoints with the same developer flag:
+
+```bash
+testronaut --dev login.mission.js -o mfa=github-test-mfa
+```
+
+To inspect MFA API traffic during a run, enable debug logging:
+
+```bash
+testronaut --debug --dev login.mission.js -o mfa=github-test-mfa
+# or
+TESTRONAUT_API_DEBUG=1 testronaut --dev login.mission.js -o mfa=github-test-mfa
+```
+
+This writes sanitized request and response details to `missions/mission_reports/api-debug.log`, including the resolved endpoint URL, status, content type, response keys, body preview, parsed response shape, and list endpoint nicknames. Session tokens, bypass secrets, and MFA code values are redacted.
+
+Notes:
+- Run `testronaut login` first so `sessionToken` exists.
+- The CLI calls the API host, not the app host.
+- The MFA API feature flag must be enabled.
+- Paid access is required by the API for paid-gated MFA operations. If the API returns a payment or access error, the mission can still ask for a manual code when human input is enabled.
+
 ---
 
 ## 📋 Reports

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+# TODO
+
+## Automated MFA Follow-Ups
+
+- [ ] Add an integration smoke test against a local or staging API fixture for `get_mfa_code`.
+- [ ] Add a staging smoke-test checklist that covers `--dev`, `--vercel-bypass`, paid access, free-user fallback, missing nickname, and expired session token behavior.
+- [ ] Consider a dedicated `testronaut mfa list` command to verify session token access and available MFA nicknames before running missions.
+- [ ] Consider a lightweight MFA preflight warning when `--dev` is used without `VERCEL_AUTOMATION_BYPASS_SECRET`, `TESTRONAUT_VERCEL_BYPASS`, or `--vercel-bypass`.
+- [ ] Consider allowing `testronaut mfa list/get` to accept `--api-base` for quick diagnostics against staging, preview, or local API hosts.
+- [ ] Track automated MFA outcomes in reports without storing raw codes.
+- [ ] Add explicit report/log redaction assertions for MFA codes, session tokens, and Vercel bypass secrets.
+- [ ] Decide how long `missions/mission_reports/api-debug.log` should be retained and whether it should rotate, append per run, or be copied into each run report bundle.
+- [ ] Decide whether `-o/--options` should support more structured formats once more run options exist.
+- [ ] Revisit whether `request_human_input` should return the code to the model or fill fields through a dedicated browser action.
+- [ ] Document a troubleshooting matrix for MFA failures: premium required, feature disabled, invalid session, missing nickname, non-JSON/app-shell response, not found, rate limited, and network error.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -86,6 +86,7 @@ if (devFlagIndex >= 0) {
   console.log(`🧪 Developer mode: using ${apiBase}`);
   args.splice(devFlagIndex, 1);
 }
+process.env.TESTRONAUT_API_BASE_EFFECTIVE = apiBase;
 
 function parseVercelBypassArgs(argsList) {
   const nextArgs = [...argsList];
@@ -146,6 +147,56 @@ function parseProviderArgs(argsList) {
     nextArgs.splice(idx, consume);
   }
   return { provider, args: nextArgs, invalid };
+}
+
+function parseRunOptionsArgs(argsList) {
+  const nextArgs = [...argsList];
+  const options = {};
+  let invalid = false;
+
+  for (let idx = 0; idx < nextArgs.length;) {
+    const rawArg = nextArgs[idx];
+    const isInline =
+      rawArg.startsWith('--options=') ||
+      rawArg.startsWith('--option=') ||
+      rawArg.startsWith('-o=');
+    const isSeparate =
+      rawArg === '--options' ||
+      rawArg === '--option' ||
+      rawArg === '-o';
+
+    if (!isInline && !isSeparate) {
+      idx += 1;
+      continue;
+    }
+
+    const rawValue = isInline
+      ? rawArg.slice(rawArg.indexOf('=') + 1)
+      : nextArgs[idx + 1] && !nextArgs[idx + 1].startsWith('-')
+        ? nextArgs[idx + 1]
+        : '';
+
+    if (!rawValue) {
+      invalid = true;
+      nextArgs.splice(idx, 1);
+      continue;
+    }
+
+    for (const part of rawValue.split(',')) {
+      const [keyRaw, ...valueParts] = part.split('=');
+      const key = String(keyRaw || '').trim();
+      const value = valueParts.join('=').trim();
+      if (!key || !value) {
+        invalid = true;
+        continue;
+      }
+      options[key] = value;
+    }
+
+    nextArgs.splice(idx, isInline ? 1 : 2);
+  }
+
+  return { options, args: nextArgs, invalid };
 }
 
 
@@ -244,6 +295,7 @@ export const __test__ = {
   parseVercelBypassArgs,
   createVercelBypassHeader,
   parseProviderArgs,
+  parseRunOptionsArgs,
   detectCliName,
 };
 
@@ -276,6 +328,20 @@ const providerOverride = providerResult.provider;
 if (providerOverride) {
   process.env.TESTRONAUT_PROVIDER = providerOverride.trim();
   console.log(`🧩 Provider override: ${process.env.TESTRONAUT_PROVIDER}`);
+}
+
+const runOptionsResult = parseRunOptionsArgs(args);
+if (runOptionsResult.invalid) {
+  console.warn('⚠️ Invalid --options value. Use key=value pairs, for example: -o mfa=github-test-mfa');
+}
+args = runOptionsResult.args;
+const cliMfaName =
+  runOptionsResult.options.mfa ||
+  runOptionsResult.options.mfaName ||
+  runOptionsResult.options['mfa-name'];
+if (cliMfaName) {
+  process.env.TESTRONAUT_MFA_NAME = String(cliMfaName).trim();
+  console.log(`🔐 MFA nickname override: ${process.env.TESTRONAUT_MFA_NAME}`);
 }
 
 // Look for --debug / --debug=<bool> / --no-debug
@@ -459,6 +525,7 @@ Options:
   --turns=<n>               Override max turns for this run (e.g., --turns=30)
   --debug[=<bool>]          Enable verbose debug logs (or set TESTRONAUT_DEBUG=1)
   --provider=<id>           Override LLM provider for this run (e.g., --provider=openai)
+  -o, --options key=value   Set run options, such as mfa=github-test-mfa
   --dev                     Use the staging API base URL
   --vercel-bypass=<secret>  Send Vercel protection bypass header for protected deployments
   --human-input[=<bool>]    Allow the agent to pause for short verification codes (default: true)

--- a/core/agent.js
+++ b/core/agent.js
@@ -135,15 +135,28 @@ Use Ground Control as your persistent mission memory about:
 - Any constraints about staying on the correct site.
       `.trim();
 
+      systemContent +=
+        '\n\n' +
+        `
+Verification codes:
+- If the app requires a TOTP/MFA code, first try get_mfa_code when an MFA nickname is known from the mission text, config, or CLI options.
+- Use the returned value promptly. If the app rejects it as expired or invalid, call get_mfa_code once more for a fresh code and retry carefully.
+- Never invent, guess, or reuse placeholder MFA digits. Only enter an MFA value that came from get_mfa_code or request_human_input.
+        `.trim();
+
       if (opts.humanInput?.enabled !== false) {
         systemContent +=
-          '\n\n' +
+          '\n' +
           `
-Human-in-the-loop verification:
-- If the app requires a TOTP, SMS, email, or similar short verification code that you cannot retrieve yourself, call request_human_input.
-- Do not ask for passwords, API keys, or long free-form text with this tool.
-- After receiving the code from the tool result, enter it into the appropriate field and continue the mission.
+- If get_mfa_code returns that MFA is unavailable, not configured, not found, not enabled, or the account lacks access, gracefully fall back to request_human_input when human input is enabled.
+- Use request_human_input for SMS, email, or other short verification codes that cannot be retrieved automatically.
+- Do not ask for passwords, API keys, or long free-form text with request_human_input.
+- After receiving a code from either tool, enter it into the appropriate field and continue the mission.
           `.trim();
+      } else {
+        systemContent +=
+          '\n' +
+          'Human input is disabled for this run. If get_mfa_code cannot provide a usable MFA code, report a graceful FAILURE with the reason.';
       }
 
       if (groundSummary) {

--- a/core/turnLoop.js
+++ b/core/turnLoop.js
@@ -107,6 +107,28 @@ function extractDocIdFromUrl(url = '') {
   return m ? m[1] : '';
 }
 
+function isMfaLikeFill(fnName, args = {}) {
+  if (fnName !== 'fill') return false;
+  const haystack = [
+    args.selector,
+    args.label,
+    args.placeholder,
+    args.name,
+    args.testId,
+    args.role,
+  ].map(v => String(v || '').toLowerCase()).join(' ');
+
+  return /\b(mfa|totp|otp|verification|2fa|code)\b/.test(haystack);
+}
+
+function getFillText(args = {}) {
+  return String(args.text ?? args.value ?? args.input ?? args.keys ?? '');
+}
+
+function safeListLabel(list = []) {
+  return Array.isArray(list) && list.length ? list.join(', ') : '(none)';
+}
+
 // Rolling token counters used for self-throttling
 let totalTokensUsed = 0;
 let turnTimestamps = [];
@@ -428,6 +450,97 @@ export const turnLoop = async (
           step.events.push(errorMessage
             ? `👤 Human-in-the-loop input ${step.humanInput.status}: ${errorMessage.replace(/^ERROR:\s*/, '')}`
             : '👤 Human-in-the-loop input provided.');
+
+          if (!errorMessage) {
+            try {
+              const parsed = JSON.parse(result);
+              agentMemory.lastVerificationInput = {
+                source: 'human_input',
+                value: parsed.value,
+                codeType: parsed.codeType || args.codeType || 'verification_code',
+              };
+            } catch {
+              // ignore malformed tool result
+            }
+          }
+        }
+
+        if (fnName === 'get_mfa_code') {
+          step.mfa = step.mfa || {};
+          step.mfa.requested = true;
+          try {
+            const parsed = JSON.parse(result);
+            step.mfa.nickname = parsed.nickname || args.nickname || null;
+            step.mfa.status = parsed.ok ? 'provided' : parsed.code || 'unavailable';
+            step.mfa.availableNicknames = parsed.availableNicknames || [];
+            step.mfa.responseKeys = parsed.responseKeys || [];
+            step.mfa.listStatus = parsed.mfaListStatus || null;
+            agentMemory.lastMfaLookup = parsed.ok
+              ? {
+                  ok: true,
+                  nickname: parsed.nickname || args.nickname || null,
+                  value: parsed.value,
+                  secondsRemaining: parsed.mfaCode?.secondsRemaining,
+                  resolvedFromList: !!parsed.resolvedFromList,
+                  requestedNickname: parsed.requestedNickname,
+                  availableNicknames: parsed.availableNicknames || [],
+                }
+              : {
+                  ok: false,
+                  nickname: parsed.nickname || args.nickname || null,
+                  code: parsed.code,
+                  error: parsed.error,
+                  availableNicknames: parsed.availableNicknames || [],
+                  responseKeys: parsed.responseKeys || [],
+                  mfaListStatus: parsed.mfaListStatus || null,
+                };
+
+            step.events.push(
+              parsed.ok
+                ? `🔐 MFA code retrieved for "${step.mfa.nickname || 'configured MFA'}".`
+                : `🔐 MFA code unavailable: ${parsed.error || parsed.code || 'unknown error'}`
+            );
+            if (parsed.ok) {
+              const detailLine = [
+                `🔐 MFA source: API`,
+                `nickname="${step.mfa.nickname || 'configured MFA'}"`,
+                parsed.resolvedFromList ? `resolvedFromList=true` : null,
+                Number.isFinite(parsed.mfaCode?.secondsRemaining)
+                  ? `secondsRemaining=${parsed.mfaCode.secondsRemaining}`
+                  : null,
+              ].filter(Boolean).join(' ');
+              console.log(detailLine);
+              step.events.push(detailLine);
+            } else {
+              const reasonLine = `🔐 MFA unavailable reason: ${parsed.code || 'unknown'} - ${parsed.error || 'unknown error'}`;
+              console.log(reasonLine);
+              step.events.push(reasonLine);
+
+              if (Array.isArray(parsed.availableNicknames)) {
+                const listLine = `🔐 MFA list endpoint nicknames: ${safeListLabel(parsed.availableNicknames)}`;
+                console.log(listLine);
+                step.events.push(listLine);
+              }
+
+              if (parsed.mfaListStatus && parsed.mfaListStatus !== 'available') {
+                const listStatusLine = `🔐 MFA list endpoint status: ${JSON.stringify(parsed.mfaListStatus)}`;
+                console.log(listStatusLine);
+                step.events.push(listStatusLine);
+              } else if (parsed.mfaListStatus === 'available') {
+                const listStatusLine = '🔐 MFA list endpoint status: available';
+                console.log(listStatusLine);
+                step.events.push(listStatusLine);
+              }
+
+              if (Array.isArray(parsed.responseKeys) && parsed.responseKeys.length) {
+                const keysLine = `🔐 MFA API response keys: ${parsed.responseKeys.join(', ')}`;
+                console.log(keysLine);
+                step.events.push(keysLine);
+              }
+            }
+          } catch {
+            step.mfa.status = errorMessage ? 'error' : 'unknown';
+          }
         }
 
         // Capture and log any file upload/download events (for reports)
@@ -460,7 +573,36 @@ export const turnLoop = async (
           // non-JSON results ignored
         }
 
-        console.log(`[tool ] ← ${fnName} result:`, errorMessage ? '❌ Failed' : '✅ Success');
+        let toolStatusLabel = errorMessage ? '❌ Failed' : '✅ Success';
+        if (fnName === 'get_mfa_code' && !errorMessage) {
+          try {
+            const parsed = JSON.parse(result);
+            toolStatusLabel = parsed.ok
+              ? '✅ Code retrieved'
+              : `⚠️ Unavailable${parsed.code ? ` (${parsed.code})` : ''}`;
+          } catch {
+            toolStatusLabel = '⚠️ Unavailable';
+          }
+        }
+
+        console.log(`[tool ] ← ${fnName} result:`, toolStatusLabel);
+
+        if (isMfaLikeFill(fnName, args)) {
+          const fillText = getFillText(args);
+          let sourceLine;
+          if (agentMemory.lastMfaLookup?.ok && fillText === agentMemory.lastMfaLookup.value) {
+            sourceLine = `🔐 MFA fill source: get_mfa_code nickname="${agentMemory.lastMfaLookup.nickname || 'configured MFA'}"`;
+          } else if (agentMemory.lastVerificationInput?.value && fillText === agentMemory.lastVerificationInput.value) {
+            sourceLine = `🔐 MFA fill source: request_human_input codeType="${agentMemory.lastVerificationInput.codeType}"`;
+          } else if (agentMemory.lastMfaLookup && !agentMemory.lastMfaLookup.ok) {
+            sourceLine = `⚠️ MFA fill source: not from get_mfa_code. Last MFA lookup failed with ${agentMemory.lastMfaLookup.code || 'unknown'}: ${agentMemory.lastMfaLookup.error || 'unknown error'}`;
+          } else {
+            sourceLine = '⚠️ MFA fill source: not from a recorded get_mfa_code or request_human_input result.';
+          }
+          console.log(sourceLine);
+          step.events.push(sourceLine);
+        }
+
         let resultForLog = result;
         if (fnName === 'request_human_input') {
           try {
@@ -474,8 +616,26 @@ export const turnLoop = async (
             resultForLog = errorMessage || 'Human input received.';
           }
         }
+        if (fnName === 'get_mfa_code') {
+          try {
+            const parsed = JSON.parse(result);
+            resultForLog = JSON.stringify({
+              ...parsed,
+              value: maskPreview(parsed.value),
+              redactedValue: maskPreview(parsed.value),
+              mfaCode: parsed.mfaCode
+                ? {
+                    ...parsed.mfaCode,
+                    code: maskPreview(parsed.mfaCode.code),
+                  }
+                : parsed.mfaCode,
+            });
+          } catch {
+            resultForLog = errorMessage || 'MFA code lookup completed.';
+          }
+        }
         const truncated = resultForLog.length > 1000 ? resultForLog.slice(0, 1000) + '…' : resultForLog;
-        step.events.push(`[tool ] ← ${fnName} result: ${errorMessage ? '❌ Failed' : '✅ Success'}`);
+        step.events.push(`[tool ] ← ${fnName} result: ${toolStatusLabel}`);
         step.events.push(`[tool ] ← ${truncated}`);
 
         // Screenshot detection (for report metadata only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@types/node": "^24.9.1",
         "periapsis": "^2.0.1",
-        "vitest": "^4.0.1"
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@dqbd/tiktoken": {
@@ -35,446 +35,38 @@
       "integrity": "sha512-grBxRSY9+/iBM205EWjbMm5ySeXQrhJyXWMP38VJd+pO2DRGraDAbi4n8J8T9M4XY1M/FHgonMcmu3J+KjcX0Q==",
       "license": "MIT"
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -813,6 +405,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -848,24 +459,20 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -874,12 +481,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -888,12 +498,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -902,26 +515,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -930,12 +532,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -944,26 +549,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -972,12 +566,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -986,40 +583,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -1028,54 +600,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -1084,12 +617,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -1098,12 +634,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -1112,26 +651,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -1140,12 +668,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1154,26 +704,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -1182,28 +721,35 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1224,9 +770,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1240,40 +786,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.1.tgz",
-      "integrity": "sha512-KtvGLN/IWoZfg68JF2q/zbDEo+UJTWnc7suYJ8RF+ZTBeBcBz4NIOJDxO4Q3bEY9GsOYhgy5cOevcVPFh4+V7g==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.1",
-        "@vitest/utils": "4.0.1",
-        "chai": "^6.0.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.1.tgz",
-      "integrity": "sha512-fwmvg8YvwSAE41Hyhul7dL4UzPhG+k2VaZCcL+aHagLx4qlNQgKYTw7coF4YdjAxSBBt0b408gQFYMX1Qeqweg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.1",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.19"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1285,26 +831,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.1.tgz",
-      "integrity": "sha512-6nq3JY/zQ91+oX1vd4fajiVNyA/HMhaF9cOw5P9cQi6ML7PRi7ilVaQ77PulF+4kvUKr9bcLm9GoAtwlVFbGzw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.1.tgz",
-      "integrity": "sha512-nxUoWmw7ZX2OiSNwolJeSOOzrrR/o79wRTwP7HhiW/lDFwQHtWMj9snMhrdvccFqanvI8897E81eXjgDbrRvqA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.1",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1312,14 +858,15 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.1.tgz",
-      "integrity": "sha512-CvfsEWutEIN/Z9ScXYup7YwlPeK9JICrV7FN9p3pVytsyh+aCHAH0PUi//YlTiQ7T8qYxJYpUrAwZL9XqmZ5ZA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.1",
-        "magic-string": "^0.30.19",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1327,9 +874,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.1.tgz",
-      "integrity": "sha512-Hj0/TBQ2EN72wDpfKiUf63mRCkE0ZiSGXGeDDvW9T3LBKVVApItd0GyQLDBIe03kWbyK9gOTEbJVVWthcLFzCg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1337,14 +884,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.1.tgz",
-      "integrity": "sha512-uRrACgpIz5sxuT87ml7xhh7EdKtW8k0N9oSFVBPl8gHB/JfLObLe9dXO6ZrsNN55FzciGIRqIEILgTQvg1eNHw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1453,9 +1001,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
-      "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1537,6 +1085,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -1574,22 +1129,14 @@
         "node": ">= 12"
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -1691,53 +1238,11 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1750,9 +1255,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2023,10 +1528,271 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2067,13 +1833,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -2084,9 +1843,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -2150,6 +1909,20 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/openai": {
@@ -2256,9 +2029,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2299,9 +2072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -2319,7 +2092,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2380,49 +2153,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/run-async": {
@@ -2553,9 +2315,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2593,21 +2355,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2617,9 +2382,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2672,18 +2437,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2699,9 +2463,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -2714,13 +2479,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2762,31 +2530,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.1.tgz",
-      "integrity": "sha512-4rwTfUNF0MExMZBiNirkzZpeyUZGOs3JD76N2qHNP9i6w6/bff7MRv2I9yFJKd1ICxzn2igpra+E4t9o2EfQhw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.1",
-        "@vitest/mocker": "4.0.1",
-        "@vitest/pretty-format": "4.0.1",
-        "@vitest/runner": "4.0.1",
-        "@vitest/snapshot": "4.0.1",
-        "@vitest/spy": "4.0.1",
-        "@vitest/utils": "4.0.1",
-        "debug": "^4.4.3",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.19",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.9.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
+        "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2800,20 +2568,23 @@
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
+        "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.1",
-        "@vitest/browser-preview": "4.0.1",
-        "@vitest/browser-webdriverio": "4.0.1",
-        "@vitest/ui": "4.0.1",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
@@ -2828,6 +2599,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -2836,6 +2613,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   "devDependencies": {
     "@types/node": "^24.9.1",
     "periapsis": "^2.0.1",
-    "vitest": "^4.0.1"
+    "vitest": "^4.1.9"
   }
 }

--- a/tests/binTests/cli.helpers.test.js
+++ b/tests/binTests/cli.helpers.test.js
@@ -116,6 +116,33 @@ describe('cli helpers', () => {
     expect(createVercelBypassHeader('')).toEqual({});
   });
 
+  it('parses run options from -o and removes them from args', () => {
+    const { parseRunOptionsArgs } = __test__;
+    const res = parseRunOptionsArgs(['-o', 'mfa=github-test-mfa', 'login.mission.js']);
+
+    expect(res.options).toEqual({ mfa: 'github-test-mfa' });
+    expect(res.args).toEqual(['login.mission.js']);
+    expect(res.invalid).toBe(false);
+  });
+
+  it('parses comma-separated inline run options', () => {
+    const { parseRunOptionsArgs } = __test__;
+    const res = parseRunOptionsArgs(['--options=mfa=github-test-mfa,foo=bar', 'login']);
+
+    expect(res.options).toEqual({ mfa: 'github-test-mfa', foo: 'bar' });
+    expect(res.args).toEqual(['login']);
+    expect(res.invalid).toBe(false);
+  });
+
+  it('flags invalid run options', () => {
+    const { parseRunOptionsArgs } = __test__;
+    const res = parseRunOptionsArgs(['--options', 'mfa', 'login']);
+
+    expect(res.options).toEqual({});
+    expect(res.args).toEqual(['login']);
+    expect(res.invalid).toBe(true);
+  });
+
   describe('detectCliName', () => {
     const { detectCliName } = __test__;
 

--- a/tests/coreTests/turnLoop.test.js
+++ b/tests/coreTests/turnLoop.test.js
@@ -12,6 +12,7 @@ const { shared } = vi.hoisted(() => {
 
       // Browser tool spies available to the chromeBrowser mock
       chromeToolSpies: {
+        fill: vi.fn(async () => 'filled'),
         click_text: vi.fn(async () => JSON.stringify({ ok: true, clicked: 'Hello' })),
         get_dom: vi.fn(async () => '<html>dom</html>'),
         screenshot: vi.fn(async () =>
@@ -23,6 +24,15 @@ const { shared } = vi.hoisted(() => {
           })
         ),
         list_local_files: vi.fn(async () => JSON.stringify({ files: ['a.pdf', 'b.pdf'] })),
+        get_mfa_code: vi.fn(async () => JSON.stringify({
+          ok: false,
+          code: 'invalid_response',
+          error: 'MFA API response did not include a recognized code field. Response keys: nickname, message.',
+          nickname: 'rudy-poo',
+          availableNicknames: ['rudy-poo', 'github-prod'],
+          mfaListStatus: 'available',
+          responseKeys: ['nickname', 'message'],
+        })),
       },
     },
   };
@@ -62,9 +72,11 @@ vi.mock('../../tools/tokenControl.js', () => ({
 vi.mock('../../tools/toolSchema.js', () => ({
   default: [
     { type: 'function', function: { name: 'click_text', description: 'click by text', parameters: {} } },
+    { type: 'function', function: { name: 'fill', description: 'fill input', parameters: {} } },
     { type: 'function', function: { name: 'get_dom', description: 'get DOM html', parameters: {} } },
     { type: 'function', function: { name: 'screenshot', description: 'take a screenshot', parameters: {} } },
     { type: 'function', function: { name: 'list_local_files', description: 'list files', parameters: {} } },
+    { type: 'function', function: { name: 'get_mfa_code', description: 'get mfa', parameters: {} } },
   ],
 }));
 
@@ -115,9 +127,11 @@ describe('turnLoop', () => {
   beforeEach(() => {
     browser = {};
     // reset spies and chat mock
+    shared.chromeToolSpies.fill.mockClear();
     shared.chromeToolSpies.click_text.mockClear();
     shared.chromeToolSpies.get_dom.mockClear();
     shared.chromeToolSpies.screenshot.mockClear();
+    shared.chromeToolSpies.get_mfa_code.mockClear();
     if (shared.chatMock) shared.chatMock.mockReset();
   });
 
@@ -228,6 +242,106 @@ describe('turnLoop', () => {
     expect(res.steps[0].result).toBe('⏳ Retrying turn');
     expect(res.steps[1].result).toBe('✅ Passed');
     expect(res.steps[2].result).toMatch(/Success/);
+  });
+
+  it('logs unavailable MFA lookups without marking the tool as a success', async () => {
+    shared.chatMock.mockResolvedValueOnce({
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'tool_mfa',
+            type: 'function',
+            function: { name: 'get_mfa_code', arguments: JSON.stringify({ nickname: 'rudy-poo' }) },
+          },
+        ],
+      },
+      usage: { total_tokens: 7 },
+    });
+
+    shared.chatMock.mockResolvedValueOnce({
+      message: { role: 'assistant', content: 'FINAL: graceful failure noted' },
+      usage: { total_tokens: 5 },
+    });
+
+    const messages = baseMessages();
+    const res = await turnLoop(browser, messages, 2, 0, 0, {}, { steps: [], missionName: 'demo' });
+
+    expect(res.success).toBe(true);
+    expect(shared.chromeToolSpies.get_mfa_code).toHaveBeenCalledWith(
+      browser,
+      { nickname: 'rudy-poo' },
+      expect.any(Object)
+    );
+    expect(res.steps[0].mfa).toMatchObject({
+      requested: true,
+      nickname: 'rudy-poo',
+      status: 'invalid_response',
+      availableNicknames: ['rudy-poo', 'github-prod'],
+      responseKeys: ['nickname', 'message'],
+      listStatus: 'available',
+    });
+    expect(res.steps[0].events).toContain(
+      '[tool ] ← get_mfa_code result: ⚠️ Unavailable (invalid_response)'
+    );
+    expect(res.steps[0].events.join('\n')).toContain('Response keys: nickname, message');
+    expect(res.steps[0].events).toContain('🔐 MFA list endpoint nicknames: rudy-poo, github-prod');
+    expect(res.steps[0].events).toContain('🔐 MFA list endpoint status: available');
+    expect(res.steps[0].events).toContain('🔐 MFA API response keys: nickname, message');
+    expect(res.steps[0].events.join('\n')).not.toContain(
+      '[tool ] ← get_mfa_code result: ✅ Success'
+    );
+  });
+
+  it('logs when an MFA field is filled with a value not sourced from MFA tools', async () => {
+    shared.chatMock.mockResolvedValueOnce({
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'tool_mfa',
+            type: 'function',
+            function: { name: 'get_mfa_code', arguments: JSON.stringify({ nickname: 'rudy-poo' }) },
+          },
+        ],
+      },
+      usage: { total_tokens: 7 },
+    });
+
+    shared.chatMock.mockResolvedValueOnce({
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'tool_fill_mfa',
+            type: 'function',
+            function: { name: 'fill', arguments: JSON.stringify({ selector: '#mfa-code', text: '123456' }) },
+          },
+        ],
+      },
+      usage: { total_tokens: 6 },
+    });
+
+    shared.chatMock.mockResolvedValueOnce({
+      message: { role: 'assistant', content: 'FINAL: graceful failure noted' },
+      usage: { total_tokens: 5 },
+    });
+
+    const messages = baseMessages();
+    const res = await turnLoop(browser, messages, 3, 0, 0, {}, { steps: [], missionName: 'demo' });
+
+    expect(res.success).toBe(true);
+    expect(shared.chromeToolSpies.fill).toHaveBeenCalledWith(
+      browser,
+      { selector: '#mfa-code', text: '123456' },
+      expect.any(Object)
+    );
+    expect(res.steps[1].events.join('\n')).toContain(
+      '⚠️ MFA fill source: not from get_mfa_code. Last MFA lookup failed with invalid_response'
+    );
   });
 
   describe('__docProgressInternals helpers', () => {

--- a/tests/toolsTests/mfaCode.test.js
+++ b/tests/toolsTests/mfaCode.test.js
@@ -1,0 +1,445 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  getMfaCode,
+  resolveMfaNickname,
+  __test__,
+} from '../../tools/mfaCode.js';
+
+function response({ ok = true, status = 200, statusText = 'OK', body = {}, text, contentType = 'application/json' } = {}) {
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: (name) => name.toLowerCase() === 'content-type' ? contentType : '',
+    },
+    text: vi.fn().mockResolvedValue(text ?? JSON.stringify(body)),
+  };
+}
+
+describe('tools/mfaCode', () => {
+  const oldEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...oldEnv };
+    vi.clearAllMocks();
+  });
+
+  it('resolves MFA nickname from args, env, and config', () => {
+    expect(resolveMfaNickname({ nickname: 'from-args' }, { mfaName: 'from-config' })).toBe('from-args');
+
+    process.env.TESTRONAUT_MFA_NAME = 'from-env';
+    expect(resolveMfaNickname({}, { mfaName: 'from-config' })).toBe('from-env');
+
+    delete process.env.TESTRONAUT_MFA_NAME;
+    expect(resolveMfaNickname({}, { mfa: { name: 'from-nested-config' } })).toBe('from-nested-config');
+  });
+
+  it('returns a graceful error when nickname is missing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      body: { nicknames: [] },
+    }));
+
+    const result = await getMfaCode(
+      {},
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'missing_nickname',
+      availableNicknames: [],
+      mfaListStatus: 'available',
+    });
+  });
+
+  it('returns a graceful error when sessionToken is missing', async () => {
+    const result = await getMfaCode({ nickname: 'github' }, { config: {} });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'missing_session_token',
+      nickname: 'github',
+    });
+  });
+
+  it('retrieves and normalizes an MFA code from the API', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      body: {
+        nickname: 'GitHub',
+        mfaCode: {
+          code: '123456',
+          expiresAt: '2026-07-02T20:00:30.000Z',
+          secondsRemaining: 20,
+        },
+      },
+    }));
+
+    const result = await getMfaCode(
+      { nickname: 'GitHub', waitForFreshCode: false },
+      {
+        apiBase: 'https://api.example.test',
+        config: { sessionToken: 'session-token' },
+        fetchImpl,
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.example.test/api/mfa?nickname=GitHub',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer session-token',
+        }),
+      })
+    );
+    expect(result).toEqual({
+      ok: true,
+      codeType: 'totp',
+      nickname: 'GitHub',
+      value: '123456',
+      redactedValue: '•••••• (6)',
+      mfaCode: {
+        code: '123456',
+        expiresAt: '2026-07-02T20:00:30.000Z',
+        secondsRemaining: 20,
+      },
+    });
+  });
+
+  it('lists MFA nicknames and auto-selects when exactly one exists', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response({
+        body: { nicknames: ['GitHub Prod'] },
+      }))
+      .mockResolvedValueOnce(response({
+        body: {
+          nickname: 'GitHub Prod',
+          mfaCode: { code: '123456', secondsRemaining: 20 },
+        },
+      }));
+
+    const result = await getMfaCode(
+      { waitForFreshCode: false },
+      { apiBase: 'https://api.example.test', config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.test/api/mfa/list',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.test/api/mfa?nickname=GitHub+Prod',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      nickname: 'GitHub Prod',
+      value: '123456',
+      resolvedFromList: true,
+      availableNicknames: ['GitHub Prod'],
+    });
+  });
+
+  it('returns available nicknames when no nickname is provided and multiple exist', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      body: { nicknames: ['GitHub Prod', 'AWS Root'] },
+    }));
+
+    const result = await getMfaCode(
+      {},
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'missing_nickname',
+      availableNicknames: ['GitHub Prod', 'AWS Root'],
+      mfaListStatus: 'available',
+    });
+    expect(result.error).toContain('GitHub Prod, AWS Root');
+  });
+
+  it('maps paid-plan failures without throwing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      ok: false,
+      status: 402,
+      statusText: 'Payment Required',
+      body: { error: 'MFA code generation requires an active paid subscription' },
+    }));
+
+    const result = await getMfaCode(
+      { nickname: 'github' },
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 402,
+      code: 'premium_required',
+      error:
+        'This Testronaut account is not eligible for automated MFA because it does not have an active paid subscription.',
+      apiError: 'MFA code generation requires an active paid subscription',
+      nickname: 'github',
+    });
+  });
+
+  it('accepts alternate API response code shapes', () => {
+    expect(__test__.normalizeApiCode({ code: '654321' })).toMatchObject({ value: '654321' });
+    expect(__test__.normalizeApiCode({ totp: { value: '123456' } })).toMatchObject({ value: '123456' });
+    expect(__test__.normalizeApiCode({ otp: { token: '234567' } })).toMatchObject({ value: '234567' });
+    expect(__test__.normalizeApiCode({ mfaCode: { mfaCode: '345678' } })).toMatchObject({ value: '345678' });
+    expect(__test__.normalizeApiCode({ mfaCode: { code: 12345 } })).toMatchObject({ value: '012345' });
+  });
+
+  it('returns safe diagnostics for unrecognized successful responses', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      body: { nickname: 'GitHub', message: 'ok but no code here' },
+    }));
+
+    const result = await getMfaCode(
+      { nickname: 'github' },
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 200,
+      code: 'invalid_response',
+      contentType: 'application/json',
+      responseKeys: ['nickname', 'message'],
+      nickname: 'github',
+    });
+    expect(result.error).toContain('Response keys: nickname, message');
+  });
+
+  it('maps missing MFA entries without throwing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      body: { error: 'MFA entry not found' },
+    }));
+
+    const result = await getMfaCode(
+      { nickname: 'github' },
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 404,
+      code: 'not_found',
+      nickname: 'github',
+    });
+  });
+
+  it('reports a clear error when the MFA code endpoint returns an app HTML shell', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({
+        contentType: 'text/html; charset=utf-8',
+        text: '<!DOCTYPE html><html><head></head><body>App shell</body></html>',
+      }))
+      .mockResolvedValueOnce(response({
+        contentType: 'text/html; charset=utf-8',
+        text: '<!DOCTYPE html><html><head></head><body>App shell</body></html>',
+      }));
+
+    const result = await getMfaCode(
+      { nickname: 'github' },
+      { apiBase: 'https://staging.api.example.test', config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://staging.api.example.test/api/mfa?nickname=github',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+        }),
+      })
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      status: 200,
+      code: 'non_json_response',
+      contentType: 'text/html; charset=utf-8',
+      nickname: 'github',
+      availableNicknames: [],
+      mfaListStatus: {
+        code: 'non_json_response',
+        status: 200,
+      },
+    });
+    expect(result.error).toMatch(/non-JSON response/i);
+    expect(result.apiError).toContain('https://staging.api.example.test/api/mfa');
+  });
+
+  it('uses the list endpoint to recover from fuzzy nickname mismatches', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: { error: 'MFA entry not found' },
+      }))
+      .mockResolvedValueOnce(response({
+        body: { nicknames: ['rudy-poo'] },
+      }))
+      .mockResolvedValueOnce(response({
+        body: {
+          nickname: 'rudy-poo',
+          mfaCode: { code: '123456', secondsRemaining: 20 },
+        },
+      }));
+
+    const result = await getMfaCode(
+      { nickname: 'rudy poo', waitForFreshCode: false },
+      { apiBase: 'https://api.example.test', config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.test/api/mfa?nickname=rudy+poo',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.test/api/mfa/list',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      'https://api.example.test/api/mfa?nickname=rudy-poo',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      nickname: 'rudy-poo',
+      value: '123456',
+      requestedNickname: 'rudy poo',
+      resolvedFromList: true,
+      availableNicknames: ['rudy-poo'],
+    });
+  });
+
+  it('adds available nicknames when a requested nickname is not found', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: { error: 'MFA entry not found' },
+      }))
+      .mockResolvedValueOnce(response({
+        body: { entries: [{ nickname: 'GitHub Prod' }, { nickname: 'AWS Root' }] },
+      }));
+
+    const result = await getMfaCode(
+      { nickname: 'missing' },
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'not_found',
+      availableNicknames: ['GitHub Prod', 'AWS Root'],
+      mfaListStatus: 'available',
+    });
+  });
+
+  it('uses the effective API base and Vercel bypass header from env', async () => {
+    process.env.TESTRONAUT_API_BASE_EFFECTIVE = 'https://staging.api.example.test/';
+    process.env.TESTRONAUT_VERCEL_BYPASS = 'bypass-secret';
+    const fetchImpl = vi.fn().mockResolvedValue(response({
+      body: { nickname: 'GitHub', mfaCode: { code: '123456', secondsRemaining: 20 } },
+    }));
+
+    await getMfaCode(
+      { nickname: 'GitHub', waitForFreshCode: false },
+      { config: { sessionToken: 'session-token' }, fetchImpl }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://staging.api.example.test/api/mfa?nickname=GitHub',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer session-token',
+          'x-vercel-protection-bypass': 'bypass-secret',
+        }),
+      })
+    );
+  });
+
+  it('writes sanitized MFA API request and response debug logs when debug is enabled', async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'testronaut-mfa-debug-'));
+    process.env.TESTRONAUT_API_DEBUG = '1';
+    process.env.TESTRONAUT_VERCEL_BYPASS = 'bypass-secret';
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response({
+        body: { nickname: 'GitHub', mfaCode: { code: '123456', secondsRemaining: 20 } },
+      }))
+      .mockResolvedValueOnce(response({
+        body: { nicknames: ['GitHub', 'AWS Root'] },
+      }));
+
+    await getMfaCode(
+      { nickname: 'GitHub', waitForFreshCode: false },
+      {
+        cwd,
+        apiBase: 'https://api.example.test',
+        config: { sessionToken: 'session-token' },
+        fetchImpl,
+      }
+    );
+
+    await getMfaCode(
+      {},
+      {
+        cwd,
+        apiBase: 'https://api.example.test',
+        config: { sessionToken: 'session-token' },
+        fetchImpl,
+      }
+    );
+
+    const logPath = path.join(cwd, 'missions/mission_reports/api-debug.log');
+    const log = fs.readFileSync(logPath, 'utf8');
+
+    expect(log).toContain('"endpoint": "get_code"');
+    expect(log).toContain('https://api.example.test/api/mfa?nickname=GitHub');
+    expect(log).toContain('"endpoint": "list"');
+    expect(log).toContain('https://api.example.test/api/mfa/list');
+    expect(log).toContain('"statusCode": 200');
+    expect(log).toContain('"responseShape": "recognized_code"');
+    expect(log).toContain('"availableNicknames"');
+    expect(log).toContain('AWS Root');
+    expect(log).toContain('<redacted>');
+    expect(log).not.toContain('session-token');
+    expect(log).not.toContain('bypass-secret');
+    expect(log).not.toContain('123456');
+  });
+
+  it('classifies feature-disabled 404s separately', () => {
+    expect(__test__.errorCodeForStatus(404, 'MFA endpoints are not enabled')).toBe('feature_disabled');
+  });
+
+  it('formats friendly account access errors', () => {
+    expect(__test__.friendlyMfaError('premium_required')).toMatch(/not eligible/i);
+  });
+
+  it('matches listed MFA nicknames case-insensitively and punctuation-insensitively', () => {
+    expect(__test__.findListedNicknameMatch('RUDY POO', ['rudy-poo'])).toBe('rudy-poo');
+    expect(__test__.findListedNicknameMatch('github prod', ['GitHub Prod'])).toBe('GitHub Prod');
+  });
+});

--- a/tests/toolsTests/toolSchema.test.js
+++ b/tests/toolsTests/toolSchema.test.js
@@ -23,6 +23,14 @@ describe('tools/toolSchema', () => {
     expect(entry.function.parameters?.properties?.maxLength?.default).toBe(64);
   });
 
+  it('includes get_mfa_code for automated TOTP retrieval', () => {
+    const entry = toolsSchema.find(t => t.function?.name === 'get_mfa_code');
+    expect(entry?.type).toBe('function');
+    expect(entry.function.description).toMatch(/TOTP MFA code/i);
+    expect(entry.function.parameters?.properties).toHaveProperty('nickname');
+    expect(entry.function.parameters?.properties?.minSecondsRemaining?.default).toBe(5);
+  });
+
   it('defines navigate and download_file with required fields', () => {
     const nav = toolsSchema.find(t => t.function?.name === 'navigate');
     const download = toolsSchema.find(t => t.function?.name === 'download_file');

--- a/tools/chromeBrowser.js
+++ b/tools/chromeBrowser.js
@@ -23,6 +23,7 @@ import fs from 'fs';
 import path from 'path';
 import { ensureBrowsers } from '../tools/playwrightSetup.js';
 import { requestHumanInput } from './humanInput.js';
+import { getMfaCode } from './mfaCode.js';
 
 const FILES_DIR = path.join('missions', 'files');
 const REPORTS_DIR = path.join('missions', 'mission_reports');
@@ -1362,6 +1363,7 @@ export const CHROME_TOOL_MAP = {
   upload_file: (b, args) => b.upload_file(args),
   download_file: (b, args) => b.download_file(args),
   list_local_files: (b, args) => b.list_local_files(args),
+  get_mfa_code: (b, args) => getMfaCode(args),
   request_human_input: (b, args, agentMemory) => requestHumanInput(args, agentMemory?.humanInput),
   resource_progress: (b, args, agentMemory) => {
     const prog = agentMemory?.docProgress;

--- a/tools/mfaCode.js
+++ b/tools/mfaCode.js
@@ -1,0 +1,637 @@
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import { loadConfig } from '../core/config.js';
+import { maskPreview } from '../core/redaction.js';
+
+export const DEFAULT_API_BASE = 'http://api.testronaut.app';
+export const DEV_API_BASE = 'https://staging.api.testronaut.app';
+
+const MIN_REMAINING_SECONDS = 5;
+const MAX_REMAINING_SECONDS = 25;
+const API_DEBUG_LOG_RELATIVE_PATH = 'missions/mission_reports/api-debug.log';
+const REDACTED = '<redacted>';
+
+const SENSITIVE_LOG_KEYS = new Set([
+  'authorization',
+  'apikey',
+  'api_key',
+  'api-key',
+  'bearer',
+  'code',
+  'mfacode',
+  'mfa_code',
+  'mfa-code',
+  'otp',
+  'password',
+  'secret',
+  'sessiontoken',
+  'session_token',
+  'session-token',
+  'token',
+  'totp',
+  'value',
+  'x-vercel-protection-bypass',
+]);
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseDebugBool(value) {
+  const normalized = cleanString(value).toLowerCase();
+  return normalized === '1' ||
+    normalized === 'true' ||
+    normalized === 'yes' ||
+    normalized === 'on';
+}
+
+function isApiDebugEnabled() {
+  return parseDebugBool(process.env.TESTRONAUT_API_DEBUG) ||
+    parseDebugBool(process.env.TESTRONAUT_DEBUG);
+}
+
+function apiDebugLogPath(cwd = process.cwd()) {
+  return path.resolve(cwd, API_DEBUG_LOG_RELATIVE_PATH);
+}
+
+function normalizeLogKey(key) {
+  return String(key || '').toLowerCase().replace(/[^a-z0-9_-]/g, '');
+}
+
+function isSensitiveLogKey(key) {
+  return SENSITIVE_LOG_KEYS.has(normalizeLogKey(key));
+}
+
+function redactHeaders(headers = {}) {
+  const redacted = {};
+  for (const [key, value] of Object.entries(headers || {})) {
+    redacted[key] = isSensitiveLogKey(key) ? REDACTED : value;
+  }
+  return redacted;
+}
+
+function redactText(text = '') {
+  return String(text)
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, `Bearer ${REDACTED}`)
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, REDACTED)
+    .replace(/("(?:authorization|apiKey|api_key|code|mfaCode|otp|secret|sessionToken|token|totp|value)"\s*:\s*)"[^"]*"/gi, `$1"${REDACTED}"`);
+}
+
+function redactLogValue(value, parentKey = '') {
+  if (isSensitiveLogKey(parentKey)) {
+    return REDACTED;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => redactLogValue(item));
+  }
+  if (value && typeof value === 'object') {
+    const redacted = {};
+    for (const [key, childValue] of Object.entries(value)) {
+      redacted[key] = redactLogValue(childValue, key);
+    }
+    return redacted;
+  }
+  if (typeof value === 'string') {
+    return redactText(value);
+  }
+  return value;
+}
+
+function safeBodyPreview(text, data, limit = 2500) {
+  const source = data && typeof data === 'object'
+    ? JSON.stringify(redactLogValue(data), null, 2)
+    : redactText(text || '');
+
+  if (source.length <= limit) return source;
+  return `${source.slice(0, limit)}... <truncated ${source.length - limit} chars>`;
+}
+
+function responseKeysForLog(data) {
+  return data && typeof data === 'object' && !Array.isArray(data)
+    ? Object.keys(data).slice(0, 20)
+    : [];
+}
+
+function writeApiDebugLog(entry, { cwd = process.cwd() } = {}) {
+  if (!isApiDebugEnabled()) return;
+
+  const filePath = apiDebugLogPath(cwd);
+  const safeEntry = redactLogValue({
+    timestamp: new Date().toISOString(),
+    ...entry,
+  });
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.appendFileSync(filePath, `${JSON.stringify(safeEntry, null, 2)}\n`, 'utf8');
+  } catch {
+    // Debug logging should never break a mission run.
+  }
+}
+
+function cleanCodeValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(Math.trunc(value)).padStart(6, '0');
+  }
+  return cleanString(value);
+}
+
+function normalizeNicknameForMatch(value) {
+  return cleanString(value).toLowerCase();
+}
+
+function compactNicknameForMatch(value) {
+  return normalizeNicknameForMatch(value).replace(/[^a-z0-9]/g, '');
+}
+
+function clampSeconds(raw, fallback = MIN_REMAINING_SECONDS) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(MAX_REMAINING_SECONDS, Math.max(0, Math.trunc(n)));
+}
+
+function bearerHeaders(sessionToken, extraHeaders = {}) {
+  const bypass =
+    cleanString(process.env.VERCEL_AUTOMATION_BYPASS_SECRET) ||
+    cleanString(process.env.TESTRONAUT_VERCEL_BYPASS);
+
+  return {
+    Accept: 'application/json',
+    ...extraHeaders,
+    Authorization: `Bearer ${sessionToken}`,
+    ...(bypass ? { 'x-vercel-protection-bypass': bypass } : {}),
+  };
+}
+
+function resolveApiBase(options = {}) {
+  return (
+    cleanString(options.apiBase) ||
+    cleanString(process.env.TESTRONAUT_API_BASE_EFFECTIVE) ||
+    cleanString(process.env.TESTRONAUT_API_BASE) ||
+    DEFAULT_API_BASE
+  ).replace(/\/+$/, '');
+}
+
+export function resolveMfaNickname(args = {}, cfg = {}) {
+  return (
+    cleanString(args.nickname) ||
+    cleanString(args.mfaName) ||
+    cleanString(args.name) ||
+    cleanString(process.env.TESTRONAUT_MFA_NAME) ||
+    cleanString(cfg.mfaName) ||
+    cleanString(cfg.mfa?.name) ||
+    cleanString(cfg.mfa?.nickname)
+  );
+}
+
+function resolveSessionToken(args = {}, cfg = {}) {
+  return (
+    cleanString(args.sessionToken) ||
+    cleanString(process.env.TESTRONAUT_SESSION_TOKEN) ||
+    cleanString(cfg.sessionToken)
+  );
+}
+
+function errorCodeForStatus(status, error = '') {
+  const normalized = String(error).toLowerCase();
+  if (status === 401) return 'invalid_session';
+  if (status === 402) return 'premium_required';
+  if (status === 404 && normalized.includes('not enabled')) return 'feature_disabled';
+  if (status === 404) return 'not_found';
+  if (status === 429) return 'rate_limited';
+  return 'api_error';
+}
+
+function friendlyMfaError(code, apiError = '') {
+  if (code === 'premium_required') {
+    return 'This Testronaut account is not eligible for automated MFA because it does not have an active paid subscription.';
+  }
+  if (code === 'invalid_session') {
+    return 'The saved Testronaut session token is invalid or expired. Run `testronaut login` again.';
+  }
+  if (code === 'feature_disabled') {
+    return 'Automated MFA is not enabled for this Testronaut environment.';
+  }
+  if (code === 'not_found') {
+    return 'No stored MFA entry was found for that nickname.';
+  }
+  if (code === 'rate_limited') {
+    return 'The MFA API is rate limited. Try again shortly.';
+  }
+  if (code === 'non_json_response') {
+    return 'The MFA API returned a non-JSON response. This usually means the CLI is pointed at the app host or a fallback page instead of the API host.';
+  }
+  return apiError || 'Unable to retrieve MFA code.';
+}
+
+function normalizeApiCode(data) {
+  const codeObject =
+    data?.mfaCode && typeof data.mfaCode === 'object'
+      ? data.mfaCode
+      : data?.code && typeof data.code === 'object'
+        ? data.code
+        : data?.totp && typeof data.totp === 'object'
+          ? data.totp
+          : data?.otp && typeof data.otp === 'object'
+            ? data.otp
+            : {
+                code:
+                  data?.mfaCode ??
+                  data?.code ??
+                  data?.totp ??
+                  data?.otp ??
+                  data?.value ??
+                  data?.token,
+              };
+
+  const value = cleanCodeValue(
+    codeObject.code ??
+      codeObject.value ??
+      codeObject.mfaCode ??
+      codeObject.totp ??
+      codeObject.otp ??
+      codeObject.token
+  );
+  if (!value) return null;
+
+  return {
+    value,
+    expiresAt: codeObject.expiresAt,
+    secondsRemaining: Number(codeObject.secondsRemaining),
+  };
+}
+
+function normalizeMfaNicknames(data) {
+  const fromNicknames = Array.isArray(data?.nicknames)
+    ? data.nicknames
+    : [];
+  const fromEntries = Array.isArray(data?.entries)
+    ? data.entries.map(entry => entry?.nickname)
+    : [];
+  const seen = new Set();
+  const nicknames = [];
+
+  for (const raw of [...fromNicknames, ...fromEntries]) {
+    const nickname = cleanString(raw);
+    const key = normalizeNicknameForMatch(nickname);
+    if (!nickname || seen.has(key)) continue;
+    seen.add(key);
+    nicknames.push(nickname);
+  }
+
+  return nicknames;
+}
+
+function findListedNicknameMatch(requestedNickname, availableNicknames = []) {
+  const requested = normalizeNicknameForMatch(requestedNickname);
+  const exact = availableNicknames.find(
+    nickname => normalizeNicknameForMatch(nickname) === requested
+  );
+  if (exact) return exact;
+
+  const compactRequested = compactNicknameForMatch(requestedNickname);
+  const compactMatches = availableNicknames.filter(
+    nickname => compactNicknameForMatch(nickname) === compactRequested
+  );
+  return compactMatches.length === 1 ? compactMatches[0] : null;
+}
+
+async function fetchMfaList({ apiBase, sessionToken, fetchImpl = fetch, cwd = process.cwd() }) {
+  const url = new URL('/api/mfa/list', `${apiBase}/`);
+  const headers = bearerHeaders(sessionToken);
+  const response = await fetchImpl(url.toString(), {
+    method: 'GET',
+    headers,
+  });
+
+  const text = await response.text();
+  const contentType = response.headers?.get?.('content-type') || response.headers?.get?.('Content-Type') || '';
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = null;
+  }
+  const availableNicknames = response.ok ? normalizeMfaNicknames(data) : [];
+
+  writeApiDebugLog({
+    type: 'mfa-api',
+    endpoint: 'list',
+    request: {
+      method: 'GET',
+      url: url.toString(),
+      headers: redactHeaders(headers),
+    },
+    response: {
+      ok: response.ok,
+      statusCode: response.status,
+      statusText: response.statusText,
+      contentType,
+      bodyLength: text.length,
+      responseKeys: responseKeysForLog(data),
+      bodyPreview: safeBodyPreview(text, data),
+    },
+    parsed: {
+      availableNicknames,
+      responseShape: data && typeof data === 'object' ? 'json' : 'non_json',
+    },
+  }, { cwd });
+
+  if (response.ok && !data) {
+    const apiError = `Expected JSON from ${url.origin}/api/mfa/list but received ${contentType || 'unknown content type'}.`;
+    return {
+      ok: false,
+      status: response.status,
+      code: 'non_json_response',
+      error: friendlyMfaError('non_json_response', apiError),
+      apiError,
+      contentType,
+      availableNicknames: [],
+    };
+  }
+
+  if (!response.ok) {
+    const apiError = data?.error || text || response.statusText || 'Unable to list MFA entries';
+    const code = errorCodeForStatus(response.status, apiError);
+    return {
+      ok: false,
+      status: response.status,
+      code,
+      error: friendlyMfaError(code, apiError),
+      apiError,
+      availableNicknames: [],
+    };
+  }
+
+  return {
+    ok: true,
+    availableNicknames,
+  };
+}
+
+async function addAvailableNicknames(result, { apiBase, sessionToken, fetchImpl, cwd }) {
+  const list = await fetchMfaList({ apiBase, sessionToken, fetchImpl, cwd });
+  return {
+    ...result,
+    availableNicknames: list.ok ? list.availableNicknames : [],
+    mfaListStatus: list.ok
+      ? 'available'
+      : {
+          code: list.code,
+          status: list.status,
+          error: list.error,
+        },
+  };
+}
+
+async function fetchMfaCode({ apiBase, sessionToken, nickname, fetchImpl = fetch, cwd = process.cwd() }) {
+  const url = new URL('/api/mfa', `${apiBase}/`);
+  url.searchParams.set('nickname', nickname);
+  const headers = bearerHeaders(sessionToken);
+
+  const response = await fetchImpl(url.toString(), {
+    method: 'GET',
+    headers,
+  });
+
+  const text = await response.text();
+  const contentType = response.headers?.get?.('content-type') || response.headers?.get?.('Content-Type') || '';
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = null;
+  }
+
+  writeApiDebugLog({
+    type: 'mfa-api',
+    endpoint: 'get_code',
+    request: {
+      method: 'GET',
+      url: url.toString(),
+      nickname,
+      headers: redactHeaders(headers),
+    },
+    response: {
+      ok: response.ok,
+      statusCode: response.status,
+      statusText: response.statusText,
+      contentType,
+      bodyLength: text.length,
+      responseKeys: responseKeysForLog(data),
+      bodyPreview: safeBodyPreview(text, data),
+    },
+    parsed: {
+      responseShape: response.ok
+        ? (data ? (normalizeApiCode(data) ? 'recognized_code' : 'unrecognized_code') : 'non_json')
+        : 'error_response',
+    },
+  }, { cwd });
+
+  if (response.ok && !data) {
+    const apiError = `Expected JSON from ${url.origin}/api/mfa but received ${contentType || 'unknown content type'}.`;
+    return {
+      ok: false,
+      status: response.status,
+      code: 'non_json_response',
+      error: friendlyMfaError('non_json_response', apiError),
+      apiError,
+      contentType,
+      nickname,
+    };
+  }
+
+  if (!response.ok) {
+    const apiError = data?.error || text || response.statusText || 'Unable to retrieve MFA code';
+    const code = errorCodeForStatus(response.status, apiError);
+    return {
+      ok: false,
+      status: response.status,
+      code,
+      error: friendlyMfaError(code, apiError),
+      apiError,
+      nickname,
+    };
+  }
+
+  const mfaCode = normalizeApiCode(data);
+  if (!mfaCode) {
+    const responseKeys = data && typeof data === 'object' && !Array.isArray(data)
+      ? Object.keys(data).slice(0, 12)
+      : [];
+    return {
+      ok: false,
+      status: response.status,
+      code: 'invalid_response',
+      error: responseKeys.length
+        ? `MFA API response did not include a recognized code field. Response keys: ${responseKeys.join(', ')}.`
+        : 'MFA API response did not include a recognized code field.',
+      contentType,
+      responseKeys,
+      nickname,
+    };
+  }
+
+  return {
+    ok: true,
+    codeType: 'totp',
+    nickname: data?.nickname || nickname,
+    value: mfaCode.value,
+    redactedValue: maskPreview(mfaCode.value),
+    mfaCode: {
+      code: mfaCode.value,
+      expiresAt: mfaCode.expiresAt,
+      secondsRemaining: Number.isFinite(mfaCode.secondsRemaining)
+        ? mfaCode.secondsRemaining
+        : undefined,
+    },
+  };
+}
+
+/**
+ * Retrieve a TOTP MFA code from the Testronaut API.
+ *
+ * @param {{ nickname?: string, mfaName?: string, name?: string, sessionToken?: string, minSecondsRemaining?: number, waitForFreshCode?: boolean }} args
+ * @param {{ cwd?: string, apiBase?: string, fetchImpl?: Function, config?: object }} options
+ * @returns {Promise<object>}
+ */
+export async function getMfaCode(args = {}, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const cfg = options.config ?? await loadConfig(cwd);
+  const nickname = resolveMfaNickname(args, cfg);
+  const sessionToken = resolveSessionToken(args, cfg);
+  const apiBase = resolveApiBase(options);
+  const minSecondsRemaining = clampSeconds(args.minSecondsRemaining);
+  const waitForFreshCode = args.waitForFreshCode !== false;
+  const fetchImpl = options.fetchImpl || fetch;
+
+  async function fetchFreshCode(resolvedNickname, extra = {}) {
+    let result = await fetchMfaCode({
+      apiBase,
+      sessionToken,
+      nickname: resolvedNickname,
+      fetchImpl,
+      cwd,
+    });
+
+    const remaining = result?.mfaCode?.secondsRemaining;
+    if (
+      result.ok &&
+      waitForFreshCode &&
+      Number.isFinite(remaining) &&
+      remaining > 0 &&
+      remaining < minSecondsRemaining
+    ) {
+      await new Promise(resolve => setTimeout(resolve, (remaining + 1) * 1000));
+      result = await fetchMfaCode({
+        apiBase,
+        sessionToken,
+        nickname: resolvedNickname,
+        fetchImpl,
+        cwd,
+      });
+    }
+
+    return {
+      ...result,
+      ...extra,
+    };
+  }
+
+  if (!nickname) {
+    if (sessionToken) {
+      const list = await fetchMfaList({ apiBase, sessionToken, fetchImpl, cwd });
+      if (list.ok && list.availableNicknames.length === 1) {
+        return fetchFreshCode(list.availableNicknames[0], {
+          resolvedFromList: true,
+          requestedNickname: '',
+          availableNicknames: list.availableNicknames,
+        });
+      }
+      return {
+        ok: false,
+        code: 'missing_nickname',
+        error: list.ok && list.availableNicknames.length
+          ? `MFA nickname is required. Available MFA nicknames: ${list.availableNicknames.join(', ')}.`
+          : 'MFA nickname is required. Pass nickname to the tool, set mfaName in testronaut-config.json, or run with -o mfa=<nickname>.',
+        availableNicknames: list.ok ? list.availableNicknames : [],
+        mfaListStatus: list.ok
+          ? 'available'
+          : {
+              code: list.code,
+              status: list.status,
+              error: list.error,
+            },
+      };
+    }
+
+    return {
+      ok: false,
+      code: 'missing_nickname',
+      error:
+        'MFA nickname is required. Pass nickname to the tool, set mfaName in testronaut-config.json, or run with -o mfa=<nickname>.',
+    };
+  }
+
+  if (!sessionToken) {
+    return {
+      ok: false,
+      code: 'missing_session_token',
+      error:
+        'No sessionToken found. Run `testronaut login` or add sessionToken to testronaut-config.json.',
+      nickname,
+    };
+  }
+
+  try {
+    const result = await fetchFreshCode(nickname);
+    if (result.ok) {
+      return result;
+    }
+
+    const resultWithList = await addAvailableNicknames(result, {
+      apiBase,
+      sessionToken,
+      fetchImpl,
+      cwd,
+    });
+
+    if (result.code === 'not_found' && resultWithList.availableNicknames?.length) {
+      const matchedNickname = findListedNicknameMatch(
+        nickname,
+        resultWithList.availableNicknames
+      );
+      if (matchedNickname && matchedNickname !== nickname) {
+        return fetchFreshCode(matchedNickname, {
+          requestedNickname: nickname,
+          resolvedFromList: true,
+          availableNicknames: resultWithList.availableNicknames,
+        });
+      }
+    }
+
+    return resultWithList;
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'network_error',
+      error: error?.message || 'Unable to reach MFA API',
+      nickname,
+    };
+  }
+}
+
+export const __test__ = {
+  resolveApiBase,
+  resolveMfaNickname,
+  errorCodeForStatus,
+  normalizeApiCode,
+  normalizeMfaNicknames,
+  findListedNicknameMatch,
+  bearerHeaders,
+  friendlyMfaError,
+  apiDebugLogPath,
+  isApiDebugEnabled,
+  redactLogValue,
+};

--- a/tools/toolSchema.js
+++ b/tools/toolSchema.js
@@ -331,6 +331,34 @@ const toolsSchema = [
   {
     type: 'function',
     function: {
+      name: 'get_mfa_code',
+      description:
+        'Retrieve a current TOTP MFA code from the Testronaut API using the configured sessionToken. Prefer this before request_human_input. If the nickname is missing or does not match, the tool can list available MFA nicknames and retry simple case/spacing/punctuation mismatches.',
+      parameters: {
+        type: 'object',
+        properties: {
+          nickname: {
+            type: 'string',
+            description: 'Nickname of the stored MFA entry, such as "github-test-mfa". Optional if mfaName is configured.'
+          },
+          minSecondsRemaining: {
+            type: 'number',
+            default: 5,
+            description: 'If the code is about to expire, wait for a fresher code when possible.'
+          },
+          waitForFreshCode: {
+            type: 'boolean',
+            default: true,
+            description: 'Whether to wait and retry when the current TOTP code has very little time remaining.'
+          }
+        },
+        required: []
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
       name: 'request_human_input',
       description:
         'Pause for a human to enter a short verification code such as TOTP, SMS, or email confirmation. Use only when the page requires a code the agent cannot obtain itself.',


### PR DESCRIPTION
## Summary

Adds automated MFA support to the Testronaut CLI.

The CLI can now retrieve a current TOTP MFA code from the Testronaut API using the project `sessionToken`, a configured/default MFA nickname, or a CLI-provided MFA nickname. This allows missions to complete MFA challenges automatically when the user has API access to a stored MFA entry, while still falling back gracefully to human input when unavailable.

## Changes

- Added `get_mfa_code` browser tool for automated TOTP retrieval.
- Supports MFA nickname resolution from:
  - mission/tool args
  - `testronaut-config.json` via `mfaName` or `mfa.nickname`
  - CLI options via `-o mfa=<nickname>`
- Uses the Testronaut API directly with `Authorization: Bearer <sessionToken>`.
- Supports `--dev` staging API mode.
- Supports Vercel-protected staging via `--vercel-bypass`, `VERCEL_AUTOMATION_BYPASS_SECRET`, or `TESTRONAUT_VERCEL_BYPASS`.
- Calls the MFA list endpoint when nickname is missing or mismatched.
- Retries simple nickname mismatches across case, spaces, and punctuation.
- Handles paid-access, feature-disabled, missing-token, missing-entry, rate-limit, network, and non-JSON/app-shell failures gracefully.
- Prevents the agent from inventing or filling guessed MFA codes.
- Logs when MFA fields are filled from a verified source vs. an unsourced value.
- Adds sanitized MFA API debug logging to `missions/mission_reports/api-debug.log`.
- Updates README with MFA usage, staging, debug, and troubleshooting notes.
- Adds CLI TODO follow-ups for MFA operational polish.

## Testing

- Added unit tests for MFA code retrieval, list lookup, nickname fallback, paid-plan failures, non-JSON staging/app-shell responses, debug logging, Vercel bypass headers, and safe diagnostics.
- Added turn-loop tests for MFA lookup logging and unsourced MFA fill detection.
- Full test suite passes on Node 22:

```bash
PATH=/home/shane/.nvm/versions/node/v22.22.3/bin:$PATH npm test
Result: 24 passed, 204 tests.
```