### PR TITLE
Add current GPT-5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current supported providers:
 
 | Provider | Example Models |
 |-----------|----------------|
-| **OpenAI** | gpt-4o, gpt-4.1, o3, gpt-5, gpt-5.1, etc. |
+| **OpenAI** | gpt-5.6, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, and legacy GPT/o-series models |
 | **Google Gemini** | gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-8b |
 
 More providers coming soon (Anthropic, Mistral, etc.).

--- a/bin/init.js
+++ b/bin/init.js
@@ -32,10 +32,10 @@ import {
   migrateLegacyConfig,
   defaultConfig,
   makeEnvTemplate,
-  openAIModels,
   geminiModels,
   pickInitialIndex
 } from './initHelpers.js';
+import { DEFAULT_OPENAI_MODEL, OPENAI_MODELS } from '../llm/openAI/models.js';
 
 export async function initializeTestronautProject() {
   // ─────────────────────────────────────────────
@@ -81,36 +81,36 @@ export async function initializeTestronautProject() {
 
     // 2b) Provider-specific model selection
     if (llmProvider === 'openai') {
-      const models = openAIModels();
+      const currentModels = OPENAI_MODELS.filter(model => !model.legacy);
+      const legacyModels = OPENAI_MODELS.filter(model => model.legacy);
+      const choices = [
+        ...currentModels.map(model => ({
+          title: `${model.label} (${model.description})`,
+          value: model.id,
+        })),
+        { title: '── Legacy models ──', disabled: true },
+        ...legacyModels.map(model => ({
+          title: `${model.label} (${model.description})`,
+          value: model.id,
+        })),
+      ];
+      const selectedIndex = choices.findIndex(choice => choice.value === config.model);
+      const defaultIndex = choices.findIndex(choice => choice.value === DEFAULT_OPENAI_MODEL);
       const { openaiModel } = await prompts({
         type: 'select',
         name: 'openaiModel',
         message: 'Select an OpenAI model for agentic workflows (function/tool calling):',
-        choices: [
-          { title: 'GPT-4.1 (general purpose)', value: 'gpt-4.1' },
-          { title: 'GPT-4.1 mini (faster, cheaper)', value: 'gpt-4.1-mini' },
-          { title: 'GPT-4o (multimodal, tool use)', value: 'gpt-4o' },
-          { title: 'GPT-4o mini (speed/cost optimized)', value: 'gpt-4o-mini' },
-          { title: 'o3 (reasoning w/ native tool use)', value: 'o3' },
-          { title: 'o4-mini (reasoning, cost-effective)', value: 'o4-mini' },
-          // GPT-5 family (availability varies)
-          { title: 'GPT-5 (previous reasoning model)', value: 'gpt-5' },
-          { title: 'GPT-5 mini (faster)', value: 'gpt-5-mini' },
-          { title: 'GPT-5 nano (lightweight)', value: 'gpt-5-nano' },
-          { title: 'GPT-5.1 (latest reasoning model)', value: 'gpt-5.1' },
-        ],
-        // Keep prior selection highlighted if present; fallback to 4.1-mini.
-        initial: pickInitialIndex(models, config.model, 'gpt-4.1-mini')
+        choices,
+        // Keep a prior selection highlighted; otherwise default to GPT-5.6.
+        initial: selectedIndex >= 0 ? selectedIndex : defaultIndex,
       });
 
       config.model = openaiModel;
 
-      // Helpful heads-up: GPT-5 access varies by account/region.
+      // API access and rate limits vary by OpenAI account and project.
       if (openaiModel?.startsWith('gpt-5')) {
         console.log(`
-⚠️  Warning: GPT-5 support may not be available for all users.
-    - Access depends on your OpenAI account/region
-    - Some capabilities may be gated or rate-limited
+ℹ️  GPT-5 availability and rate limits depend on your OpenAI account and project.
 `);
       }
     } else if (llmProvider === 'gemini') {

--- a/bin/initHelpers.js
+++ b/bin/initHelpers.js
@@ -25,6 +25,8 @@
  *   const models = openAIModels();
  */
 
+import { OPENAI_MODELS } from '../llm/openAI/models.js';
+
 /**
  * Ensures backward compatibility for older configs where
  * provider information may have been implied by the model field.
@@ -94,18 +96,7 @@ GEMINI_API_KEY=AIza...
  * @returns {string[]} Array of OpenAI model names
  */
 export function openAIModels() {
-  return [
-    'gpt-4.1',
-    'gpt-4.1-mini',
-    'gpt-4o',
-    'gpt-4o-mini',
-    'o3',
-    'o4-mini',
-    'gpt-5',
-    'gpt-5-mini',
-    'gpt-5-nano',
-    'gpt-5.1',
-  ];
+  return OPENAI_MODELS.map(({ id }) => id);
 }
 
 /**

--- a/core/turnLoop.js
+++ b/core/turnLoop.js
@@ -41,7 +41,8 @@ import {
   tokenUseCoolOff, 
   recordTokenUsage, 
   pruneOldTokenUsage,
-  updateLimitsFromHeaders
+  updateLimitsFromHeaders,
+  warnIfContextNearLimit
 } from '../tools/tokenControl.js';
 import { resolveProviderModel } from '../llm/modelResolver.js';
 import { getLLM } from '../llm/llmFactory.js';
@@ -349,6 +350,7 @@ export const turnLoop = async (
       // ─────────────────────────────────────────────
       // STEP 2: Request next reasoning turn from model
       // ─────────────────────────────────────────────
+      await warnIfContextNearLimit(MODEL_ID, { messages, tools: activeToolsSchema });
       const { message, usage, headers } = await llm.chat({
         model: MODEL_ID,
         messages,

--- a/llm/modelResolver.js
+++ b/llm/modelResolver.js
@@ -9,7 +9,7 @@
  *   1) Env: TESTRONAUT_PROVIDER / TESTRONAUT_MODEL
  *   2) Config file (provider + model)
  *   3) Legacy config (model === "openai", no provider)
- *   4) Default: { provider: "openai", model: "gpt-4o" }
+ *   4) Default: { provider: "openai", model: "gpt-5.6" }
  *
  * Related tests: tests/llmTests/modelResolver.test.js
  * Used by: core/turnLoop.js, llm/llmFactory.js
@@ -17,6 +17,7 @@
 
 import path from 'path';
 import fs from 'fs';
+import { DEFAULT_OPENAI_MODEL } from './openAI/models.js';
 
 /**
  * Resolve provider & model, honoring env overrides and safe defaults.
@@ -50,7 +51,7 @@ export function resolveProviderModel(opts = {}) {
 
       // Legacy: model === "openai" and no provider
       if (!cfg?.provider && cfg?.model === 'openai') {
-        return { provider: 'openai', model: envModel || 'gpt-4o' };
+        return { provider: 'openai', model: envModel || DEFAULT_OPENAI_MODEL };
       }
     }
   } catch (e) {
@@ -60,6 +61,6 @@ export function resolveProviderModel(opts = {}) {
   // 3) Defaults
   return {
     provider: envProvider || 'openai',
-    model: envModel || 'gpt-4o',
+    model: envModel || DEFAULT_OPENAI_MODEL,
   };
 }

--- a/llm/openAI/models.js
+++ b/llm/openAI/models.js
@@ -1,0 +1,32 @@
+/**
+ * Supported OpenAI model aliases and the capabilities Testronaut relies on.
+ * Dated snapshots and specialized Chat, Codex, Pro, and Cyber models are
+ * intentionally excluded from the interactive catalog.
+ */
+export const OPENAI_MODELS = [
+  { id: 'gpt-5.6', label: 'GPT-5.6 Sol', description: 'flagship capability', contextWindow: 1050000, chatToolReasoningEffort: 'none' },
+  { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'balanced intelligence and cost', contextWindow: 1050000, chatToolReasoningEffort: 'none' },
+  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'cost-sensitive, high-volume workloads', contextWindow: 1050000, chatToolReasoningEffort: 'none' },
+  { id: 'gpt-5.5', label: 'GPT-5.5', description: 'previous flagship model', contextWindow: 1050000 },
+
+  { id: 'gpt-5.4', label: 'GPT-5.4', description: 'earlier professional model', contextWindow: 1050000, legacy: true },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'earlier balanced model', contextWindow: 400000, legacy: true },
+  { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', description: 'earlier high-volume model', contextWindow: 400000, legacy: true },
+  { id: 'gpt-5.2', label: 'GPT-5.2', description: 'previous frontier model', contextWindow: 400000, legacy: true },
+  { id: 'gpt-5.1', label: 'GPT-5.1', description: 'legacy reasoning model', legacy: true },
+  { id: 'gpt-5', label: 'GPT-5', description: 'legacy reasoning model', legacy: true },
+  { id: 'gpt-5-mini', label: 'GPT-5 mini', description: 'legacy faster model', legacy: true },
+  { id: 'gpt-5-nano', label: 'GPT-5 nano', description: 'legacy lightweight model', legacy: true },
+  { id: 'gpt-4.1', label: 'GPT-4.1', description: 'legacy general-purpose model', legacy: true },
+  { id: 'gpt-4.1-mini', label: 'GPT-4.1 mini', description: 'legacy faster model', legacy: true },
+  { id: 'gpt-4o', label: 'GPT-4o', description: 'legacy multimodal model', legacy: true },
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini', description: 'legacy cost-optimized model', legacy: true },
+  { id: 'o3', label: 'o3', description: 'legacy reasoning model', legacy: true },
+  { id: 'o4-mini', label: 'o4-mini', description: 'legacy cost-effective reasoning model', legacy: true },
+];
+
+export const DEFAULT_OPENAI_MODEL = 'gpt-5.6';
+
+export function getOpenAIModel(modelId) {
+  return OPENAI_MODELS.find(({ id }) => id === modelId);
+}

--- a/llm/openAI/openaiProvider.js
+++ b/llm/openAI/openaiProvider.js
@@ -20,6 +20,7 @@
  */
 
 import OpenAI from 'openai';
+import { getOpenAIModel } from './models.js';
 
 export class OpenAIProvider {
   constructor({ apiKey } = {}) {
@@ -33,11 +34,21 @@ export class OpenAIProvider {
    * @returns {Promise<{message:any, usage?:{total_tokens?:number, providerRaw?:any}, headers?:any}>}
    */
   async chat({ model, messages, tools }) {
-    const res = await this.client.chat.completions.create({
+    const request = {
       model,
       messages,
       tools,
-    });
+    };
+
+    // GPT-5.6 defaults to medium reasoning, but Chat Completions does not
+    // support combining reasoning with function tools. Responses API support
+    // is tracked separately; keep the current tool loop compatible meanwhile.
+    const chatToolReasoningEffort = getOpenAIModel(model)?.chatToolReasoningEffort;
+    if (tools?.length && chatToolReasoningEffort) {
+      request.reasoning_effort = chatToolReasoningEffort;
+    }
+
+    const res = await this.client.chat.completions.create(request);
 
     // OpenAI already returns an OpenAI-like message and usage structure.
     const message = res.choices?.[0]?.message ?? { role: 'assistant', content: '' };

--- a/tests/binTests/initHelpersTests/models.test.js
+++ b/tests/binTests/initHelpersTests/models.test.js
@@ -4,6 +4,17 @@ import { openAIModels, geminiModels, isKnownModel, pickInitialIndex } from '../.
 describe('model helpers', () => {
   it('lists known models', () => {
     expect(openAIModels()).toContain('gpt-4o');
+    expect(openAIModels()).toEqual(expect.arrayContaining([
+      'gpt-5.2',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.4-nano',
+      'gpt-5.5',
+      'gpt-5.6',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ]));
+    expect(openAIModels()).not.toContain('gpt-5.3');
     expect(geminiModels()).toContain('gemini-2.5-flash');
   });
 

--- a/tests/coreTests/turnLoop.test.js
+++ b/tests/coreTests/turnLoop.test.js
@@ -67,6 +67,7 @@ vi.mock('../../tools/tokenControl.js', () => ({
     totalTokensUsed: turnTimestamps.reduce((a, [, t]) => a + t, 0),
   })),
   updateLimitsFromHeaders: vi.fn(() => {}),
+  warnIfContextNearLimit: vi.fn(async () => ({ warned: false })),
 }));
 
 vi.mock('../../tools/toolSchema.js', () => ({

--- a/tests/llmTests/modelResolver.test.js
+++ b/tests/llmTests/modelResolver.test.js
@@ -62,13 +62,13 @@ describe('resolveProviderModel', () => {
     writeConfig(temp, { model: 'openai' });
 
     const res = resolveProviderModel({ cwd: temp });
-    expect(res).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    expect(res).toEqual({ provider: 'openai', model: 'gpt-5.6' });
   });
 
   it('returns defaults when config missing', () => {
     const temp = makeTempProject();
     const res = resolveProviderModel({ cwd: temp });
-    expect(res).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    expect(res).toEqual({ provider: 'openai', model: 'gpt-5.6' });
   });
 
   it('returns defaults when JSON parsing fails', () => {
@@ -77,7 +77,7 @@ describe('resolveProviderModel', () => {
 
     const res = resolveProviderModel({ cwd: temp });
     expect(res.provider).toBe('openai');
-    expect(res.model).toBe('gpt-4o');
+    expect(res.model).toBe('gpt-5.6');
   });
 
   it('trims env vars and treats empty strings as absent', () => {
@@ -90,7 +90,7 @@ describe('resolveProviderModel', () => {
     process.env.TESTRONAUT_MODEL = '   ';
     res = resolveProviderModel();
     // falls back to defaults when env vars are just whitespace
-    expect(res).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    expect(res).toEqual({ provider: 'openai', model: 'gpt-5.6' });
   });
 
   it('prefers config when only provider is in env and model only in config', () => {

--- a/tests/llmTests/openAIProvider.test.js
+++ b/tests/llmTests/openAIProvider.test.js
@@ -78,6 +78,24 @@ describe('OpenAIProvider', () => {
     });
   });
 
+  it.each(['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'disables reasoning for %s function tools on Chat Completions',
+    async (model) => {
+      const prov = new OpenAIProvider({ apiKey: 'sk-abc' });
+      const tools = [{ type: 'function', function: { name: 'doThing', parameters: { type: 'object' } } }];
+
+      await prov.chat({ model, messages: [{ role: 'user', content: 'go' }], tools });
+
+      expect(shared.lastCreateArgs).toMatchObject({ model, tools, reasoning_effort: 'none' });
+    }
+  );
+
+  it('does not add a reasoning override to GPT-5.6 requests without tools', async () => {
+    const prov = new OpenAIProvider({ apiKey: 'sk-abc' });
+    await prov.chat({ model: 'gpt-5.6', messages: [] });
+    expect(shared.lastCreateArgs).not.toHaveProperty('reasoning_effort');
+  });
+
   it('returns normalized message, usage, and headers', async () => {
     const prov = new OpenAIProvider({ apiKey: 'sk-abc' });
     const { message, usage, headers } = await prov.chat({

--- a/tests/toolsTests/tokenControl.test.js
+++ b/tests/toolsTests/tokenControl.test.js
@@ -33,6 +33,7 @@ import {
   tokenUseCoolOff,
   recordTokenUsage,
   pruneOldTokenUsage,
+  warnIfContextNearLimit,
   __resetTokenControlForTests,
 } from '../../tools/tokenControl.js';
 
@@ -111,6 +112,24 @@ describe('tokenControl', () => {
       // sanity check it actually changed (unless defaults already 1234)
       if (before.tpm !== 1234) expect(after.tpm).not.toBe(before.tpm);
     });
+
+    it('uses tier-1 defaults without letting generic GPT-5 rules shadow variants', () => {
+      expect(getCurrentTokenLimit('gpt-5.6').tpm).toBe(500000);
+      expect(getCurrentTokenLimit('gpt-5.6-luna').tpm).toBe(500000);
+      expect(getCurrentTokenLimit('gpt-5.4-nano').tpm).toBe(200000);
+      expect(getCurrentTokenLimit('gpt-5-mini').tpm).toBe(240000);
+      expect(getCurrentTokenLimit('gpt-5-nano').tpm).toBe(600000);
+    });
+  });
+
+  it('warns without truncating when known context usage crosses the threshold', async () => {
+    tiktokenMocks.encoding_for_model_impl.mockReturnValue(encMock);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await warnIfContextNearLimit('gpt-5.2', '1234567890', 0.00002);
+    expect(result.warned).toBe(true);
+    expect(result.contextWindow).toBe(400000);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   describe('rolling window + cooldown', () => {

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,17 @@
+# Testronaut CLI TODO
+
+## OpenAI provider follow-ups
+
+- Migrate the OpenAI adapter from Chat Completions to the Responses API in a
+  dedicated change. Preserve Testronaut's provider-neutral message and tool-call
+  contract, add response-ID/reasoning-state handling, normalize usage and raw
+  headers, and cover multi-turn tool continuation with unit and API smoke tests.
+  Once migrated, remove the GPT-5.6 Chat Completions compatibility override that
+  sets `reasoning_effort` to `none` for function-tool requests.
+- Add active context budgeting after its behavior is designed and tested. Use
+  model context/output metadata to reserve response and reasoning capacity, then
+  apply explicit history compaction or summarization rules. Do not silently
+  truncate mission instructions, current DOM state, or unmatched tool calls.
+- Learn effective OpenAI TPM/RPM limits from successful response headers and
+  rate-limit errors. Prefer observed project/model limits over inferring a named
+  account tier; retain the environment override and conservative startup values.

--- a/tools/tokenControl.js
+++ b/tools/tokenControl.js
@@ -22,6 +22,7 @@
 
 import { encoding_for_model, get_encoding } from '@dqbd/tiktoken';
 import { wait } from './turnLoopUtils.js';
+import { getOpenAIModel } from '../llm/openAI/models.js';
 
 /**
  * Dynamic token-per-minute limits by model family.
@@ -35,10 +36,16 @@ import { wait } from './turnLoopUtils.js';
  */
 const DEFAULT_LIMITS = [
   // ── OpenAI (newer first) ────────────────────────────────────────────────
+  { test: /^gpt-5\.6-luna(-|$)/i,        tpm: 500000 },
+  { test: /^gpt-5\.6(-|$)/i,             tpm: 500000 },
+  { test: /^gpt-5\.5(-|$)/i,             tpm: 500000 },
+  { test: /^gpt-5\.4-nano(-|$)/i,        tpm: 200000 },
+  { test: /^gpt-5\.4(-|$)/i,             tpm: 500000 },
+  { test: /^gpt-5\.2(-|$)/i,             tpm: 500000 },
   { test: /^gpt-5.1(-|$)/i,             tpm: 120000 },
-  { test: /^gpt-5(-|$)/i,               tpm:  90000 },
   { test: /^gpt-5-mini(-|$)/i,          tpm: 240000 },
   { test: /^gpt-5-nano(-|$)/i,          tpm: 600000 },
+  { test: /^gpt-5(-|$)/i,               tpm:  90000 },
 
   { test: /^gpt-4o(-|$)/i,              tpm: 450000 },
   { test: /^gpt-4\.1(-|$)/i,            tpm:1000000 },
@@ -142,6 +149,25 @@ export const tokenEstimate = async (model, text) => {
   console.log(`🧠 Estimated token count (approx, ${model}): ${approx}`);
   return approx;
 };
+
+/**
+ * Warn when a request is close to a known model context window. This is a
+ * diagnostic only: Testronaut does not truncate or compact content here.
+ */
+export async function warnIfContextNearLimit(model, payload, threshold = 0.9) {
+  const contextWindow = getOpenAIModel(model)?.contextWindow;
+  if (!contextWindow) return { warned: false };
+
+  const estimatedTokens = await tokenEstimate(model, payload);
+  const warned = estimatedTokens >= contextWindow * threshold;
+  if (warned) {
+    console.warn(
+      `⚠️ Estimated request context for ${model} is ${estimatedTokens}/${contextWindow} tokens. ` +
+      'Testronaut will send it unchanged; consider reducing mission or tool history.'
+    );
+  }
+  return { warned, estimatedTokens, contextWindow };
+}
 
 /* ---------------- Dynamic limit resolution ---------------- */
 


### PR DESCRIPTION
## Summary
- add stable GPT-5.2, GPT-5.4, GPT-5.5, and GPT-5.6 aliases
- make GPT-5.6 the default and group older models as legacy
- add context warnings and tier-aware TPM defaults
- keep GPT-5.6 function tools compatible with Chat Completions
- record Responses API and context-budgeting follow-ups

## Validation
- 210 tests pass on Node 22
- manually exercised from testronaut-examples